### PR TITLE
Unconditionnally include oce-config.h in inc/* header files

### DIFF
--- a/inc/OpenGl_FontMgr.hxx
+++ b/inc/OpenGl_FontMgr.hxx
@@ -7,9 +7,7 @@
 # include <stdlib.h>
 #endif
 
-#ifdef HAVE_CONFIG_H
-# include <oce-config.h>
-#endif
+#include <oce-config.h>
 
 #ifdef HAVE_FTGL_NEWER212
 # include <FTGL/ftgl.h>

--- a/inc/Standard_Macro.hxx
+++ b/inc/Standard_Macro.hxx
@@ -7,9 +7,7 @@
 #ifndef _Standard_Macro_HeaderFile
 # define _Standard_Macro_HeaderFile
 
-#ifdef HAVE_CONFIG_H
 # include <oce-config.h>
-#endif /* HAVE_CONFIG_H */
 
 // Standard OCC macros: Handle(), STANDARD_TYPE()
 # define   Handle(ClassName)  Handle_##ClassName

--- a/inc/Standard_values.h
+++ b/inc/Standard_values.h
@@ -22,20 +22,18 @@ Facility : CAS-CADE V1.3A
 #error "Wrong compiler options has been detected. Add /DWNT option for proper compilation!!!!!"
 #endif
 
-#ifndef WNT
-#ifdef HAVE_CONFIG_H
-# include <oce-config.h>
-#endif
+#include <oce-config.h>
 
-#ifdef OCE_HAVE_CLIMITS
-# include <climits>
-#elif defined (OCE_HAVE_LIMITS)
-# include <limits>
-#elif defined (OCE_HAVE_LIMITS_H)
-# include <limits.h>
-#else
-#error "check config.h file or compilation options: OCE_HAVE_CLIMITS, OCE_HAVE_LIMITS, or OCE_HAVE_LIMITS_H should be defined"
-#endif
+#ifndef WNT
+# ifdef OCE_HAVE_CLIMITS
+#  include <climits>
+# elif defined (OCE_HAVE_LIMITS)
+#  include <limits>
+# elif defined (OCE_HAVE_LIMITS_H)
+#  include <limits.h>
+# else
+#  error "check oce-config.h file or compilation options: OCE_HAVE_CLIMITS, OCE_HAVE_LIMITS, or OCE_HAVE_LIMITS_H should be defined"
+# endif
 #endif
 
 

--- a/inc/Xw_Extension.h
+++ b/inc/Xw_Extension.h
@@ -22,9 +22,7 @@
 #define min(a,b) 	(a>b ? b : a)
 #endif
 
-#ifdef HAVE_CONFIG_H
-# include <oce-config.h>
-#endif
+#include <oce-config.h>
 
 #ifdef HAVE_X11_EXTENSIONS_TRANSOLV_H
 #include <X11/extensions/transovl.h>


### PR DESCRIPTION
Applications which depend on OCE have still to pass
-DHAVE_CONFIG_H flag in order to compile, which is pretty
annoying.

Fixes https://github.com/tpaviot/oce/issues/15
