### PR TITLE
Fixes wrong Extrema_CurveTool adaptor function call.

### DIFF
--- a/inc/Extrema_CurveTool.lxx
+++ b/inc/Extrema_CurveTool.lxx
@@ -207,7 +207,7 @@ inline gp_Parab Extrema_CurveTool::Parabola(const Adaptor3d_Curve& C)
 
  inline Standard_Boolean Extrema_CurveTool::IsRational(const Adaptor3d_Curve& C)
 {
-  return C.Degree();
+  return C.IsRational();
 }
 
 //=======================================================================


### PR DESCRIPTION
The wrong function call was hidden by the unsigned int Standard_Boolean type
