### PR TITLE
[warning-fix][implicit-conversion-from-wider-type]

### DIFF
--- a/inc/Dynamic_FuzzyDefinitionsDictionary.hxx
+++ b/inc/Dynamic_FuzzyDefinitionsDictionary.hxx
@@ -104,9 +104,13 @@ private:
 
 
 Handle_TCollection_HAsciiString thefilename;
-Standard_Integer thetime;
 Handle_Dynamic_SequenceOfFuzzyDefinitions thesequenceoffuzzydefinitions;
 
+#ifdef _MSC_VER
+__time64_t thetime;
+#else
+time_t thetime;
+#endif
 
 };
 

--- a/inc/Dynamic_MethodDefinitionsDictionary.hxx
+++ b/inc/Dynamic_MethodDefinitionsDictionary.hxx
@@ -108,9 +108,13 @@ private:
 
 
 Handle_TCollection_HAsciiString thefilename;
-Standard_Integer thetime;
 Handle_Dynamic_SequenceOfMethodDefinitions thesequenceofmethoddefinitions;
 
+#ifdef _MSC_VER
+__time64_t thetime;
+#else
+time_t thetime;
+#endif
 
 };
 

--- a/inc/Materials_MaterialsDictionary.hxx
+++ b/inc/Materials_MaterialsDictionary.hxx
@@ -89,9 +89,13 @@ private:
 
 
 Handle_TCollection_HAsciiString thefilename;
-Standard_Integer thetime;
 Handle_Materials_MaterialsSequence thematerialssequence;
 
+#ifdef _MSC_VER
+__time64_t thetime;
+#else
+time_t thetime;
+#endif
 
 };
 

--- a/inc/Units_Lexicon.hxx
+++ b/inc/Units_Lexicon.hxx
@@ -85,7 +85,7 @@ private:
 
 
 Handle_TCollection_HAsciiString thefilename;
-Standard_Integer thetime;
+time_t thetime;
 Handle_Units_TokensSequence thesequenceoftokens;
 
 

--- a/inc/Units_UnitsLexicon.hxx
+++ b/inc/Units_UnitsLexicon.hxx
@@ -72,7 +72,7 @@ private:
 
 
 Handle_TCollection_HAsciiString thefilename;
-Standard_Integer thetime;
+time_t thetime;
 
 
 };


### PR DESCRIPTION
Changed some of the interface types (inc files) related to time_t to correct some implicit casts.

Last chance to get this in 0.5 :)
Denis had some doubts about the changes, I have rechecked in MSVC and look good.
- no initializer list is changed
- time_t and __time64_t were used as appropriate
- the fields are all for internal use

of course a specific unit test here would be appropriate, still not done
