### PR TITLE
[warning-fix][comparison-between-different-enums]

### DIFF
--- a/src/OpenGl/OpenGl_TextureBox.cxx
+++ b/src/OpenGl/OpenGl_TextureBox.cxx
@@ -519,8 +519,7 @@ static void MyBindTextureEXT(TextureID ID, int Context)
   if (textab[ID].use_bind_texture[Context])
   {
     /* OCC11904 - make sure that the correct texture is bound before drawing */
-	// @todo Check here if it is correct : compare .status with the wrong ENUM type (the value matches)
-    GLenum aParamName = textab[ID].status == TEXDATA_1D ? 
+    GLenum aParamName = texdata[data].status == TEXDATA_1D ?
 GL_TEXTURE_BINDING_1D : GL_TEXTURE_BINDING_2D;
     GLint aCurrTex = -1;
     glGetIntegerv( aParamName, &aCurrTex );
@@ -537,8 +536,7 @@ GL_TEXTURE_BINDING_1D : GL_TEXTURE_BINDING_2D;
 #endif /* GL_EXT_texture_object */
   {
     /* OCC11904 - make sure that the correct texture is bound before drawing */
-	// @todo Check here if it is correct : compare .status with the wrong ENUM type (the value matches)
-    GLenum aParamName = textab[ID].status == TEXDATA_1D ? 
+    GLenum aParamName = texdata[data].status == TEXDATA_1D ?
 GL_TEXTURE_BINDING_1D : GL_TEXTURE_BINDING_2D;
     GLint aCurrTex = -1;
     glGetIntegerv( aParamName, &aCurrTex );


### PR DESCRIPTION
In module TKOpenGL, fixed the two remaining GCC warnings of the form :
  "comparison between ‘enum texStatus’ and ‘enum texDataStatus’"
Obviously texdata[data].status is wanted instead of textab[ID].status.
  enum texDataStatus conveys the dimensional of the texture (1D or 2D),
  whereas enum texStatus only conveys the "allocated" information.
