### PR TITLE
Workaround for cmake bug that prevented build in Win64+MSVC+static libs

### DIFF
--- a/adm/cmake/OccBuildKit.cmake
+++ b/adm/cmake/OccBuildKit.cmake
@@ -95,6 +95,12 @@ IF(DEFINED X11_FONT_PATH)
 	SET_SOURCE_FILES_PROPERTIES("${${PROJECT_NAME}_SOURCE_DIR}/src/OSD/OSD_FontMgr.cxx" PROPERTIES COMPILE_FLAGS "-DX11_FONT_PATH=\"${X11_FONT_PATH}\"")
 ENDIF(DEFINED X11_FONT_PATH)
 
+# Workaround for Cmake bug #0011240 (see http://public.kitware.com/Bug/view.php?id=11240)
+# Win64+MSVC+static libs = linker error
+IF(MSVC AND (NOT ${PROJECT_NAME}_BUILD_SHARED_LIB) AND (BIT EQUAL 64))
+  set_target_properties(${TOOLKIT} PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x64")
+ENDIF()
+
 # Set dependencies for thit ToolKit
 IF ( NOT "${TOOLKIT}" STREQUAL "TKernel" )
 	LIST(REMOVE_DUPLICATES TOOLKIT_DEPENDS)


### PR DESCRIPTION
This is a workaround for a cmake bug (still open) that prevented MSVC compilation in Win64+static libs
