### PR TITLE
Let HashCode call HashCode(Standard_Address,Standard_Integer), defined in

### DIFF
--- a/src/Standard/Standard_Transient.cxx
+++ b/src/Standard/Standard_Transient.cxx
@@ -1,4 +1,5 @@
 #include <Standard_Transient.hxx>
+#include <Standard_Address.hxx>
 
 //
 // The Initialization of the Standard_Transient variables
@@ -58,7 +59,7 @@ Standard_Boolean Standard_Transient::IsKind (const Standard_CString theTypeName)
 //============================================================================
 Standard_Integer Standard_Transient::HashCode(const Standard_Integer Lim) const
 {
-  return ::HashCode(this, Lim);
+  return ::HashCode((Standard_Address)this, Lim);
 }
 
 


### PR DESCRIPTION
Let HashCode call HashCode(Standard_Address,Standard_Integer), defined in Standard_Address.hxx

The current implementation calls HashCode(Handle_Standard_Transient,Standard_Integer)
due to implicit conversion operator.  But if object is allocated on the stack,
a segmentation fault occurs when the Handle_Standard_Transient temporary object
is deleted.  This happens if MMGT_OPT is set and different from 1.

Fixes issue #113
