### PR TITLE
Explicitely specify 64bit UndefinedAdress as long long unsigned int

### DIFF
--- a/inc/Handle_Standard_Persistent.hxx
+++ b/inc/Handle_Standard_Persistent.hxx
@@ -26,7 +26,7 @@
 
 #ifndef PUndefinedAddress 
 #ifdef _OCC64
-#define PUndefinedAddress ((Standard_Persistent *)0xfefdfefdfefd0000)
+#define PUndefinedAddress ((Standard_Persistent *)0xfefdfefdfefd0000llu)
 #else
 #define PUndefinedAddress ((Standard_Persistent *)0xfefd0000)
 #endif

--- a/inc/Handle_Standard_Transient.hxx
+++ b/inc/Handle_Standard_Transient.hxx
@@ -21,7 +21,7 @@
 
 #ifndef UndefinedHandleAddress 
 #ifdef _OCC64
-#define UndefinedHandleAddress ((Standard_Transient *)0xfefdfefdfefd0000)
+#define UndefinedHandleAddress ((Standard_Transient *)0xfefdfefdfefd0000llu)
 #else
 #define UndefinedHandleAddress ((Standard_Transient *)0xfefd0000)
 #endif


### PR DESCRIPTION
This change is required for parsing OCE source code with gccxml (used by pythonocc).
