### PR TITLE
Use ull instead of llu for unsigned long long suffix. This makes it compa

### DIFF
--- a/inc/Handle_Standard_Persistent.hxx
+++ b/inc/Handle_Standard_Persistent.hxx
@@ -26,7 +26,7 @@
 
 #ifndef PUndefinedAddress 
 #ifdef _OCC64
-#define PUndefinedAddress ((Standard_Persistent *)0xfefdfefdfefd0000llu)
+#define PUndefinedAddress ((Standard_Persistent *)0xfefdfefdfefd0000ull)
 #else
 #define PUndefinedAddress ((Standard_Persistent *)0xfefd0000)
 #endif

--- a/inc/Handle_Standard_Transient.hxx
+++ b/inc/Handle_Standard_Transient.hxx
@@ -21,7 +21,7 @@
 
 #ifndef UndefinedHandleAddress 
 #ifdef _OCC64
-#define UndefinedHandleAddress ((Standard_Transient *)0xfefdfefdfefd0000llu)
+#define UndefinedHandleAddress ((Standard_Transient *)0xfefdfefdfefd0000ull)
 #else
 #define UndefinedHandleAddress ((Standard_Transient *)0xfefd0000)
 #endif


### PR DESCRIPTION
Use ull instead of llu for unsigned long long suffix. This makes it compatible with MSVC and fixes bug #151
Gcc testing required :)
