### PR TITLE
Put test configuration files in a specific dir inside the CMAKE_BINARY_DI

### DIFF
--- a/test/STEPImport_test/CMakeLists.txt
+++ b/test/STEPImport_test/CMakeLists.txt
@@ -4,5 +4,7 @@ SET(step_file_ap214_1 ${CMAKE_SOURCE_DIR}/test/data/STEP/as1-oc-214.stp)
 SET(step_file_ap214_2 ${CMAKE_SOURCE_DIR}/test/data/STEP/io1-cm-214.stp)
 SET(step_file_ap214_3 ${CMAKE_SOURCE_DIR}/test/data/STEP/sg1-c5-214.stp)
 
-CONFIGURE_FILE( ${CMAKE_CURRENT_SOURCE_DIR}/STEPImport_test_config.h.cmake ${CMAKE_CURRENT_SOURCE_DIR}/STEPImport_test_config.h )
+CONFIGURE_FILE( ${CMAKE_CURRENT_SOURCE_DIR}/STEPImport_test_config.h.cmake ${CMAKE_BINARY_DIR}/testconfig/STEPImport_test_config.h )
+INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/testconfig)
+
 ADD_OCE_TEST(STEPImport_test "TKernel;TKSTEP")


### PR DESCRIPTION
Put test configuration files in a specific dir inside the CMAKE_BINARY_DIR, so the configuration files don't pollute the source dir.
This is importand in particular when one does out-of-source builds.

I've optionally added a CMAKE_BINARY_DIR/testconfig/ subdir , so we can put all the files there, maybe one day it will be a singe common header.
The other option was to use CMAKE_CURRENT_BINARY_DIR
