### PR TITLE
Make sure libglu ad GL/glu.h are installed, not just libgl & GL/gl.h.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,7 +295,7 @@ IF(${PROJECT_NAME}_VISUALISATION)
 	ENDIF(NOT WIN32)
 
 	IF (NOT APPLE)
-		FIND_PACKAGE(OpenGL REQUIRED)
+		FIND_PACKAGE(OpenGL COMPONENTS gl glu REQUIRED)
 	ELSE (NOT APPLE)
 		# under OSX, builtin FindOpenGl.cmake returns Cocoa OpenGL implementation
 		# oce requires the X11 based OpenGL


### PR DESCRIPTION
Currently the find_package command returns without error even if just libgl is installed. It needs to check for libglu as well.

I'm not sure if I got the component names correct so treat this as a proof of concept and not functional code.
