### PR TITLE
Protect inclusion of oce-config.h

### DIFF
--- a/inc/OpenGl_FontMgr.hxx
+++ b/inc/OpenGl_FontMgr.hxx
@@ -7,7 +7,9 @@
 # include <stdlib.h>
 #endif
 
+#ifdef HAVE_CONFIG_H
 #include <oce-config.h>
+#endif
 
 #ifdef HAVE_FTGL_NEWER212
 # include <FTGL/ftgl.h>

--- a/inc/Standard_Macro.hxx
+++ b/inc/Standard_Macro.hxx
@@ -7,8 +7,9 @@
 #ifndef _Standard_Macro_HeaderFile
 # define _Standard_Macro_HeaderFile
 
+#ifdef HAVE_CONFIG_H
 # include <oce-config.h>
-
+#endif
 // Standard OCC macros: Handle(), STANDARD_TYPE()
 # define   Handle(ClassName)  Handle_##ClassName
 # define   STANDARD_TYPE(aType)   aType##_Type_()

--- a/inc/Standard_values.h
+++ b/inc/Standard_values.h
@@ -22,7 +22,9 @@ Facility : CAS-CADE V1.3A
 #error "Wrong compiler options has been detected. Add /DWNT option for proper compilation!!!!!"
 #endif
 
+#ifdef HAVE_CONFIG_H
 #include <oce-config.h>
+#endif
 
 #ifndef WNT
 # ifdef OCE_HAVE_CLIMITS

--- a/inc/Xw_Extension.h
+++ b/inc/Xw_Extension.h
@@ -22,7 +22,9 @@
 #define min(a,b) 	(a>b ? b : a)
 #endif
 
+#ifdef HAVE_CONFIG_H
 #include <oce-config.h>
+#endif
 
 #ifdef HAVE_X11_EXTENSIONS_TRANSOLV_H
 #include <X11/extensions/transovl.h>


### PR DESCRIPTION
Needed in order to support succesull compilation of oce to non
cmake platforms, including WOK.
