### PR TITLE
Preprocessor issues corrected

### DIFF
--- a/src/Draw/Draw.cxx
+++ b/src/Draw/Draw.cxx
@@ -531,7 +531,11 @@ void Draw::Load(Draw_Interpretor& theDI, const TCollection_AsciiString& theKey,
 #endif
     aPluginLibrary +=  aPluginResource->Value(theKey.ToCString());
 #ifdef WNT
+#ifdef OCE_DEBUG_POSTFIX 
 	aPluginLibrary += OCE_DEBUG_POSTFIX ".dll";
+#else
+	aPluginLibrary += ".dll";
+#endif /* OCE_DEBUG_POSTFIX */
 #elif __APPLE__
     aPluginLibrary += ".dylib";
 #elif defined (HPUX) || defined(_hpux)

--- a/src/Graphic3d/Graphic3d_GraphicDevice.cxx
+++ b/src/Graphic3d/Graphic3d_GraphicDevice.cxx
@@ -126,7 +126,7 @@ Handle(Aspect_GraphicDriver) Graphic3d_GraphicDevice::GraphicDriver () const {
 
 }
 
-#ifdef OCE_BUILD_SHARED_LIB
+#if !defined(OCE_BUILD_STATIC_LIB) && !defined(HAVE_NO_DLL)
 void Graphic3d_GraphicDevice::SetGraphicDriver () {
 
 Standard_CString TheShr;

--- a/src/Graphic3d/Graphic3d_WNTGraphicDevice.cxx
+++ b/src/Graphic3d/Graphic3d_WNTGraphicDevice.cxx
@@ -44,7 +44,7 @@ Handle(Aspect_GraphicDriver) Graphic3d_WNTGraphicDevice::GraphicDriver () const 
 
 }
 
-#ifdef OCE_BUILD_SHARED_LIB
+#if !defined(OCE_BUILD_STATIC_LIB) && !defined(HAVE_NO_DLL)
 void Graphic3d_WNTGraphicDevice::SetGraphicDriver () 
 {
 
@@ -52,7 +52,11 @@ void Graphic3d_WNTGraphicDevice::SetGraphicDriver ()
   OSD_Function new_GLGraphicDriver;
   Standard_CString TheShr = getenv("CSF_GraphicShr");
   if ( ! TheShr || ( strlen( TheShr ) == 0 ) )
+#ifdef OCE_DEBUG_POSTFIX
 	  TheShr = "TKOpenGl" OCE_DEBUG_POSTFIX ".dll";
+#else
+	  TheShr = "TKOpenGl.dll";
+#endif /* OCE_DEBUG_POSTFIX */
 
   MySharedLibrary.SetName ( TheShr );
   Result = MySharedLibrary.DlOpen (OSD_RTLD_LAZY);

--- a/src/Plugin/Plugin.cxx
+++ b/src/Plugin/Plugin.cxx
@@ -47,7 +47,11 @@ Handle(Standard_Transient) Plugin::Load(const Standard_GUID& aGUID)
 #endif
     thePluginLibrary +=  PluginResource->Value(theResource.ToCString());
 #ifdef WNT
+#ifdef OCE_DEBUG_POSTFIX
 	thePluginLibrary += OCE_DEBUG_POSTFIX ".dll";
+#else
+	thePluginLibrary += ".dll";
+#endif /* OCE_DEBUG_POSTFIX */
 #elif defined(__APPLE__)
     thePluginLibrary += ".dylib";
 #elif defined (HPUX) || defined(_hpux)


### PR DESCRIPTION
Resolves issues for non defined macros in non cmake platforms.
Also resolves an issue where the default action should be to use
shared libraries instead of static ones. WARNING : Needs changes
to CMakeLists.txt file to conform with the macro change.
