### PR TITLE
Resolves a possible bcc32 compiler bug.

### DIFF
--- a/src/ShapeFix/ShapeFix_ComposeShell.cxx
+++ b/src/ShapeFix/ShapeFix_ComposeShell.cxx
@@ -6,6 +6,10 @@
 //    abv  22.07.99 implementing patch indices
 //    svv  10.01.00 porting on DEC
 
+#ifdef __BORLANDC__
+#pragma option -x-
+#endif
+
 #include <ShapeFix_ComposeShell.ixx>
 
 #include <Precision.hxx>


### PR DESCRIPTION
For a strange reason this file must not have
exception handling compiler option enabled,
otherwise an internal compiler error occurs.
