### PR TITLE
Macro fixes in Draw package

### DIFF
--- a/inc/Draw_Viewer.hxx
+++ b/inc/Draw_Viewer.hxx
@@ -27,6 +27,8 @@
 # else
 #  define __Draw_API /*__declspec( dllimport )*/
 # endif
+#else
+# define __Draw_API  
 #endif
 #else
 #  define __Draw_API  

--- a/inc/Draw_Window.hxx
+++ b/inc/Draw_Window.hxx
@@ -188,6 +188,8 @@ void GetNextEvent(Event&);
 # else
 #  define __Draw_API __declspec( dllimport )
 # endif
+#else
+# define __Draw_API
 #endif
 
 // definition de la classe Segment


### PR DESCRIPTION
In draw package there was a case (building with HAVE_NO_DLL outside
cmake build system) that the import or export decorator of a symbol
would not be defined in any case, and result in compiler error.
