### PR TITLE
OCE_DEBUG_POSTFIX undefined in non cmake envs.

### DIFF
--- a/src/Draw/Draw.cxx
+++ b/src/Draw/Draw.cxx
@@ -531,7 +531,11 @@ void Draw::Load(Draw_Interpretor& theDI, const TCollection_AsciiString& theKey,
 #endif
     aPluginLibrary +=  aPluginResource->Value(theKey.ToCString());
 #ifdef WNT
+#ifdef OCE_DEBUG_POSTFIX 
 	aPluginLibrary += OCE_DEBUG_POSTFIX ".dll";
+#else
+	aPluginLibrary += ".dll";
+#endif /* OCE_DEBUG_POSTFIX */
 #elif __APPLE__
     aPluginLibrary += ".dylib";
 #elif defined (HPUX) || defined(_hpux)

--- a/src/Graphic3d/Graphic3d_WNTGraphicDevice.cxx
+++ b/src/Graphic3d/Graphic3d_WNTGraphicDevice.cxx
@@ -52,7 +52,11 @@ void Graphic3d_WNTGraphicDevice::SetGraphicDriver ()
   OSD_Function new_GLGraphicDriver;
   Standard_CString TheShr = getenv("CSF_GraphicShr");
   if ( ! TheShr || ( strlen( TheShr ) == 0 ) )
+#ifdef OCE_DEBUG_POSTFIX
 	  TheShr = "TKOpenGl" OCE_DEBUG_POSTFIX ".dll";
+#else
+	  TheShr = "TKOpenGl.dll";
+#endif /* OCE_DEBUG_POSTFIX */
 
   MySharedLibrary.SetName ( TheShr );
   Result = MySharedLibrary.DlOpen (OSD_RTLD_LAZY);

--- a/src/Plugin/Plugin.cxx
+++ b/src/Plugin/Plugin.cxx
@@ -47,7 +47,11 @@ Handle(Standard_Transient) Plugin::Load(const Standard_GUID& aGUID)
 #endif
     thePluginLibrary +=  PluginResource->Value(theResource.ToCString());
 #ifdef WNT
+#ifdef OCE_DEBUG_POSTFIX
 	thePluginLibrary += OCE_DEBUG_POSTFIX ".dll";
+#else
+	thePluginLibrary += ".dll";
+#endif /* OCE_DEBUG_POSTFIX */
 #elif defined(__APPLE__)
     thePluginLibrary += ".dylib";
 #elif defined (HPUX) || defined(_hpux)


### PR DESCRIPTION
This symbol should be used only and when defined by
the build environment.Resolves non cmake building.

Continuation from previous #171
