### PR TITLE
Bcc needs two functions declared as global

### DIFF
--- a/src/BRepMesh/BRepMesh_CellFilter.hxx
+++ b/src/BRepMesh/BRepMesh_CellFilter.hxx
@@ -10,3 +10,11 @@
 #include <BRepMesh_CircleInspector.hxx>
 
 typedef NCollection_CellFilter<BRepMesh_CircleInspector> BRepMesh_CellFilter;
+
+#ifdef __BORLANDC__
+  // definition of global functions is needed for map
+  Standard_Integer HashCode (const NCollection_CellFilter<BRepMesh_CircleInspector>::Cell &aCell, const Standard_Integer theUpper)
+  { return aCell.HashCode(theUpper); }
+  Standard_Boolean IsEqual (const NCollection_CellFilter<BRepMesh_CircleInspector>::Cell &aCell1, const NCollection_CellFilter<BRepMesh_CircleInspector>::Cell &aCell2)
+  { return aCell1.IsEqual(aCell2); }
+#endif


### PR DESCRIPTION
This fix has been introduced again in oce in past, but
lost due to upstream changes.Corrects bcc compilation issue.
