### PR TITLE
stdint.h and stdlib.h inclusion for bcc

### DIFF
--- a/src/OSD/OSD_MAllocHook.cxx
+++ b/src/OSD/OSD_MAllocHook.cxx
@@ -5,7 +5,7 @@
 
 #include <OSD_MAllocHook.hxx>
 
-#if !defined(WNT) || defined(__MINGW32__)
+#if !defined(WNT) || defined(__MINGW32__) || defined(__BORLANDC__)
 #if !defined __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
 #endif


### PR DESCRIPTION
While WNT does not include those headers, mingw and
borland needs them.
