### PR TITLE
Removal of __BORLANDC__ deprecated macros

### DIFF
--- a/src/Draw/CommandWindow.cxx
+++ b/src/Draw/CommandWindow.cxx
@@ -16,9 +16,6 @@
 #include <MainWindow.h>
 #include <Draw_Appli.hxx>
 
-#ifdef __BORLANDC__
-#pragma link "tcl85.lib"
-#endif
 
 /****************************************************\
 *  CommandWindow.cxx :

--- a/src/OpenGl/OpenGl_FontMgr.cxx
+++ b/src/OpenGl/OpenGl_FontMgr.cxx
@@ -10,11 +10,6 @@
 
 #define DEFAULT_FONT_HEIGHT 16
 
-#ifdef __BORLANDC__
-#pragma link "freetype.lib"
-#pragma link "ftgl_dynamic_MTD.lib"
-#endif
-
 float h_scale = 0;
 
 void dump_texture( int id);


### PR DESCRIPTION
Removes not used any more macros
