### PR TITLE
Disable BSpline Mesher Option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,8 @@ IF( NOT "${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" LESS 2.8 )
 ENDIF( NOT "${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" LESS 2.8 )
 OPTION_WITH_DEFAULT( ${PROJECT_NAME}_ADD_HEADERS "Add headers to project files" OFF )
 MARK_AS_ADVANCED(${PROJECT_NAME}_ADD_HEADERS)
+OPTION_WITH_DEFAULT( ${PROJECT_NAME}_DISABLE_BSPLINE_MESHER "Disable BSpline Mesher" OFF )
+MARK_AS_ADVANCED(${PROJECT_NAME}_DISABLE_BSPLINE_MESHER)
 
 # The default for the DEB define is ON for all the platforms , in debug mode.
 # In MSVC it is not desirable to have it ON by default, since users must 

--- a/oce_build_config.h.cmake
+++ b/oce_build_config.h.cmake
@@ -272,3 +272,6 @@
 
 /* Whether OCE is build as static lib */
 #cmakedefine OCE_BUILD_STATIC_LIB
+
+/* Whether disable or not the bspline mesher */
+#cmakedefine OCE_DISABLE_BSPLINE_MESHER

--- a/src/BRepMesh/BRepMesh_FastDiscretFace.cxx
+++ b/src/BRepMesh/BRepMesh_FastDiscretFace.cxx
@@ -866,8 +866,7 @@ void BRepMesh_FastDiscretFace::InternalVertices(const Handle(BRepAdaptor_HSurfac
       }
     }
   }
-  //disable the BSpline mesher until http://github.com/tpaviot/oce/issues/143 is fixed
-  #if 0
+#if !defined(OCE_DISABLE_BSPLINE_MESHER)
   else if (thetype == GeomAbs_BezierSurface || thetype == GeomAbs_BSplineSurface)
   {
     //define resolutions


### PR DESCRIPTION
Hello,
in OCE-0.7.0 we disabled the BSpline mesher.
I did some tests at work using some real world models, and I ended up with disabling this change. Many NURBS models , with the same precision, look ugly. It seems that the
calculated normals are much worse. I can't post the originals here, but I'm finding a way to recreate similar cases that I'll add as tests.To solve the issues I found I had to increase the precision
which led to a global slowdown.
I don't want to discuss again the current mesher limitations, and please don't take this as rant, but just as a feedback.
To point for this is that IMHO we should be a bit more carefoul when doing these breaking changes, at least if we want a relatively stable OCE behavoir. 
Of course the really cool thing about OCE is that one can revert the commits and have the desired behavoir :)
Personally I prefer overmeshed to undermeshed/ugly normal models, but this can change depending on the application field.

Anyway, we can use this pull request to discuss again:
- If we should have an option to disable the bspline mesher (until it gets better)
- The default for that option

To me, it is YES,OFF. The current code reflect this, but can be easily changed.
Let's try to have a more complete scenario (i.e overmeshed vs. undermeshed models), I will try to provide both and add them in this branch during the next week.
