### PR TITLE
Drop null curve while importing STEP files.

### DIFF
--- a/src/StepToGeom/StepToGeom_MakeCurve.cxx
+++ b/src/StepToGeom/StepToGeom_MakeCurve.cxx
@@ -35,6 +35,11 @@
 
 Standard_Boolean StepToGeom_MakeCurve::Convert (const Handle(StepGeom_Curve)& SC, Handle(Geom_Curve)& CC)
 {
+  //Drop the null curve here.
+  if (SC.IsNull ()) {
+    return Standard_False;
+  }
+  
   if (SC->IsKind(STANDARD_TYPE(StepGeom_Line))) {
     const Handle(StepGeom_Line) L = Handle(StepGeom_Line)::DownCast(SC);
     return StepToGeom_MakeLine::Convert(L,*((Handle(Geom_Line)*)&CC));


### PR DESCRIPTION
OpenCASCADE 6.3 STEP translator would be export surface of linear
extrusion with a null swept curve. Something like this:

```
 #705 = SURFACE_OF_LINEAR_EXTRUSION('',$  /*   NUL REF   */,#706);
```

Returning Standard_False instead of throwing exceptions when the curve
is null.
