### PR TITLE
Bugfix: std::streamsize replacement for int

### DIFF
--- a/inc/LDOM_OSStream.hxx
+++ b/inc/LDOM_OSStream.hxx
@@ -59,7 +59,7 @@ class LDOM_SBuffer : public streambuf
     Standard_EXPORT virtual int underflow();
     //virtual int uflow();
 
-    Standard_EXPORT virtual int xsputn(const char* s, int n);
+    Standard_EXPORT virtual int xsputn(const char* s, std::streamsize n);
     //virtual int xsgetn(char* s, int n);
     //virtual int sync();
 

--- a/src/LDOM/LDOM_OSStream.cxx
+++ b/src/LDOM/LDOM_OSStream.cxx
@@ -111,7 +111,7 @@ int LDOM_SBuffer::underflow()
 //function : xsputn()
 //purpose  : redefined virtual
 //=======================================================================
-int LDOM_SBuffer::xsputn(const char* aStr, int n)
+int LDOM_SBuffer::xsputn(const char* aStr, std::streamsize n)
 {
   int aLen = n + 1;
   int freeLen = myMaxBuf - myCurString->len - 1;


### PR DESCRIPTION
Patch submitted by Simon Floery, please review.

"""
I was trying OpenCascade's XML parser (LDOM*) the other day and stumbled across a bug that appears at least on recent Ubuntu systems (depends on how the platform defines std::streamsize). In src/LDOM/LDOM_OSStream.hxx, LDOM_SBuffer::xsputn is declared with int arguments to overload std::streambuf::xsputn, however std::streamsize arguments would be correct (cf. http://www.cplusplus.com/reference/iostream/streambuf/xsputn/).
"""
