### PR TITLE
Fix syntax error in OSD_FileNode.cxx

### DIFF
--- a/src/OSD/OSD_FileNode.cxx
+++ b/src/OSD/OSD_FileNode.cxx
@@ -16,7 +16,7 @@
 
 #if!defined(TM_IN_SYS_TIME) && defined(HAVE_TIME_H)
 # include <time.h>
-#elif HAVE_SYS_TIME_H
+#elif defined(HAVE_SYS_TIME_H)
 # include <sys/time.h>
 #endif
 


### PR DESCRIPTION
Fix contributed by Massimo Del Fedele. Please review.

Original post:
"""
In OSD_FileNode.cxx, from line 17 :
# if!defined(TM_IN_SYS_TIME) && defined(HAVE_TIME_H)
# include <time.h>
# elif HAVE_SYS_TIME_H
# include <sys/time.h>
# endif
# elif HAVE_SYS_TIME_H should be replaced with #elif defined(HAVE_SYS_TIME_H)

"""
