### PR TITLE
Bugfix: Standard_Program error is not Raised

### DIFF
--- a/src/Poly/Poly_CoherentTriangulation.cxx
+++ b/src/Poly/Poly_CoherentTriangulation.cxx
@@ -575,7 +575,7 @@ void Poly_CoherentTriangulation::RemoveLink (Poly_CoherentLink& theLink)
         else if (iNode == pTri[i]->Node(2))
           const_cast<Poly_CoherentTriangle *>(pTri[i])->mypLink[2] = 0L;
         else
-          Standard_ProgramError("Poly_CoherentTriangulation::RemoveLink: "
+          Standard_ProgramError::Raise("Poly_CoherentTriangulation::RemoveLink: "
                                 " wrong connectivity between triangles");
       }
     }
@@ -650,7 +650,7 @@ Standard_Boolean Poly_CoherentTriangulation::FindTriangle
         else if (aTri.Node(1) == theLink.Node(1))
           pTri[1] = &aTri;
       } else
-        Standard_ProgramError("Poly_CoherentTriangulation::FindTriangle : "
+        Standard_ProgramError::Raise("Poly_CoherentTriangulation::FindTriangle : "
                               " Data incoherence detected");
       if (pTri[0] && pTri[1])
         break;


### PR DESCRIPTION
This fixes an issue reported by cppcheck-1.52:

[Poly/Poly_CoherentTriangulation.cxx:578]: (error) instance of "Standard_ProgramError" object destroyed immediately
[Poly/Poly_CoherentTriangulation.cxx:653]: (error) instance of "Standard_ProgramError" object destroyed immediately
