### PR TITLE
Let a mingw64 TKernel works in Wine

### DIFF
--- a/adm/cmake/TKernel/CMakeLists.txt
+++ b/adm/cmake/TKernel/CMakeLists.txt
@@ -1,6 +1,7 @@
 SET(TOOLKIT TKernel)
 
 SET(TOOLKIT_MODULES
+	StdFail
 	FSD
 	MMgt
 	OSD
@@ -9,7 +10,6 @@ SET(TOOLKIT_MODULES
 	Resource
 	SortTools
 	Standard
-	StdFail
 	Storage
 	TColStd
 	TCollection


### PR DESCRIPTION
Currently Wine [1] cannot load TKernel.dll. When loading it explicitly with the LoadLibrary system call a ERROR_NOACCESS error is raised. I get the same behavior when running an executable link to TKernel.dll.

I do not reproduce this on Windows. I only tried with the mingw64 compiler (32bit flavor).

I didn't found the real cause of the bug. I don't even know if it's in Wine or in Mingw64. But I found this fix which let me think that's it's related to exception management.

I don't think it would have any impact on other architecture so even if it's dark magic I think it can be merged.

[1] http://www.winehq.org
