### PR TITLE
Bugfix: out of bound

### DIFF
--- a/src/XCAFPrs/XCAFPrs_AISObject.cxx
+++ b/src/XCAFPrs/XCAFPrs_AISObject.cxx
@@ -3,6 +3,8 @@
 // Author:	Andrey BETENEV
 //		<abv@doomox.nnov.matra-dtv.fr>
 
+#define BUC60577	//TP_14012011 Fix out of bound.
+
 #include <XCAFPrs_AISObject.ixx>
 #include <TCollection_ExtendedString.hxx>
 #include <gp_Pnt.hxx>


### PR DESCRIPTION
cppcheck-1.52 reports the following error:
[XCAFPrs/XCAFPrs_AISObject.cxx:96]: (error) Array 'X[2]' index 2 out of bounds
[XCAFPrs/XCAFPrs_AISObject.cxx:96]: (error) Array 'Y[2]' index 2 out of bounds
[XCAFPrs/XCAFPrs_AISObject.cxx:96]: (error) Array 'Z[2]' index 2 out of bounds

Current implementation is:
"""
  Standard_Real X[2],Y[2],Z[2];
[..]
  Indx [0]=1;Indx [1]=2;Indx [2]=4;Indx [3]=3;
  Indx [4]=5;Indx [5]=6;Indx [6]=8;Indx [7]=7;
  Indx [8]=1;Indx [9]=3;Indx [10]=7;Indx [11]=5;
  Indx [12]=2;Indx [13]=4;Indx [14]=8;Indx [15]=6;
  B.Get(X[0], Y[0], Z[0], X[1], Y[1], Z[1]);
  Indx [0]=1;Indx [1]=2;Indx [2]=3;Indx [3]=4;Indx [4]=5;Indx [5]=6;Indx [6]=7;
  Indx [7]=8;Indx [8]=1;Indx [9]=2;Indx [10]=6;Indx [10]=5;Indx [10]=3;
  Indx [10]=4;Indx [10]=8;Indx [10]=7;
  B.Get(X[1], Y[1], Z[1], X[2], Y[2], Z[2]);
"""

BUC60577 is not defined, then X[2], Y[2] and Z[2] or out of X,Y and Z bounds.

Defining BUC60577 fixes the issue.
