### PR TITLE
On Windows, use stat instead of _stat to use time_t on 32 and 64 bits

### DIFF
--- a/inc/Standard_Time.hxx
+++ b/inc/Standard_Time.hxx
@@ -1,3 +1,6 @@
+#ifndef _Standard_Time_HeaderFile
+#define _Standard_Time_HeaderFile
+
 // File    : Standard_Time.hxx
 // Created : Fri Jan 13 2012 for OpenCascade Community edition
 // Author  : Fotis Sioutis <sfotis at gmail dot com>
@@ -7,8 +10,6 @@
 /* time.h is well standardised across various platforms */
 #include <time.h>
 
-#if defined( _MSC_VER ) && defined ( _TIME64_T_DEFINED )
-#define Standard_Time __time64_t
-#else 
-#define Standard_Time time_t
+typedef time_t Standard_Time;
+
 #endif

--- a/src/Dynamic/Dynamic_FuzzyDefinitionsDictionary.cxx
+++ b/src/Dynamic/Dynamic_FuzzyDefinitionsDictionary.cxx
@@ -35,11 +35,6 @@
 # include <strings.h>
 #endif
 
-#ifdef WNT
-//#define strcasecmp _stricoll
-#define stat _stat
-#endif
-
 //=======================================================================
 //function : Dynamic_FuzzyDefinitionsDictionary
 //purpose  : 

--- a/src/Dynamic/Dynamic_MethodDefinitionsDictionary.cxx
+++ b/src/Dynamic/Dynamic_MethodDefinitionsDictionary.cxx
@@ -35,10 +35,6 @@
 #ifdef HAVE_STRINGS_H
 # include <strings.h>
 #endif
-#ifdef WNT
-#define stat _stat
-//#define strcasecmp _stricoll
-#endif
 
 //=======================================================================
 //function : Dynamic_MethodDefinitionsDictionary

--- a/src/Materials/Materials_MaterialsDictionary.cxx
+++ b/src/Materials/Materials_MaterialsDictionary.cxx
@@ -32,9 +32,6 @@
 #include <Quantity_Color.hxx>
 #include <TCollection_AsciiString.hxx>
 
-#ifdef WNT
-#define stat _stat
-#endif
 //#define strcasecmp _stricoll
 #include <stdio.h>
 //#endif


### PR DESCRIPTION
In `Standard_Time.hxx`, define `Standard_Time` via a `typedef` instead of a `#define`,
like other `Standard_*` definitions in `Standard_Typedef.hxx`.
