### PR TITLE
include stdio.h for older tcl versions

### DIFF
--- a/src/Draw/Draw_Window.cxx
+++ b/src/Draw/Draw_Window.cxx
@@ -22,9 +22,6 @@
 #include <TCollection_AsciiString.hxx>
 #include <Image_PixMap.hxx>
 
-/* Earlier versions of tcl protect inclusion of stdio.h , and it is needed 
-   for gets definition */
-   
 #include <stdio.h>
 
 extern Draw_Interpretor theCommands;
@@ -130,7 +127,6 @@ defaultPrompt:
 #include <Draw_WindowBase.hxx>
 #include <X11/XWDFile.h>
 
-#include <stdio.h>
 #include <tk.h>
 
 /*


### PR DESCRIPTION
older tcl.h versions do not include (macro protect) stdio.h header which is needed by oce code (gets function).
