### PR TITLE
Fix OSX conflict return type in LDOM_SBuffer::xsputn overload

### DIFF
--- a/inc/LDOM_OSStream.hxx
+++ b/inc/LDOM_OSStream.hxx
@@ -59,7 +59,7 @@ class LDOM_SBuffer : public streambuf
     Standard_EXPORT virtual int underflow();
     //virtual int uflow();
 
-    Standard_EXPORT virtual int xsputn(const char* s, std::streamsize n);
+    Standard_EXPORT virtual std::streamsize xsputn(const char* s, std::streamsize n);
     //virtual int xsgetn(char* s, int n);
     //virtual int sync();
 

--- a/src/LDOM/LDOM_OSStream.cxx
+++ b/src/LDOM/LDOM_OSStream.cxx
@@ -111,7 +111,7 @@ int LDOM_SBuffer::underflow()
 //function : xsputn()
 //purpose  : redefined virtual
 //=======================================================================
-int LDOM_SBuffer::xsputn(const char* aStr, std::streamsize n)
+std::streamsize LDOM_SBuffer::xsputn(const char* aStr, std::streamsize n)
 {
   int aLen = n + 1;
   int freeLen = myMaxBuf - myCurString->len - 1;


### PR DESCRIPTION
Commit a60844d breaks master on OSX SL (conflict return type in LDOM_SBuffer::xsputn). This branch fixes compilation error.
