### PR TITLE
Fixed missing brackets in OSD_FontMgr.cxx/if condition

### DIFF
--- a/src/OSD/OSD_FontMgr.cxx
+++ b/src/OSD/OSD_FontMgr.cxx
@@ -165,9 +165,11 @@ void OSD_FontMgr::InitFontDataBase() {
   Standard_Character *font_dir = new Standard_Character[ req_size + strlen("\\Fonts\\") + 1 ]  ;  
 
   if( !strcpy( font_dir, windir_var ) )
+  {
     delete [] windir_var;
     delete [] font_dir;
     return  ;   
+  }
   if( !strcat( font_dir, "\\Fonts\\" ) )
     return ;  
 


### PR DESCRIPTION
This branch fixes an issue reported by @pdolbey (#246). These issues were discussed at #247: the decision is to first fix the OSD_FontMgr.cxx regression, then release 0.9.1 and postpone other issues since they require a deep investigation.
