### PR TITLE
Do not set OCE_EXTRA_WARNINGS when OCE_TESTING is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1121,7 +1121,6 @@ ENDIF(${PROJECT_NAME}_BUNDLE_AUTOINSTALL)
 # UnitTesting #
 ###############
 IF(${PROJECT_NAME}_TESTING)
-	SET( ${PROJECT_NAME}_EXTRA_WARNINGS ON CACHE BOOL "Extra warnings required by testing framework" FORCE)
 	INCLUDE(CTest)
 	ENABLE_TESTING()
 	SUBDIRS(test)


### PR DESCRIPTION
Otherwise everything is rebuilt when enabling OCE_TESTING.
Fix issue #237
