### PR TITLE
TopAbs_State is not a class or a namespace

### DIFF
--- a/src/TopOpeBRepDS/TopOpeBRepDS_repvg.cxx
+++ b/src/TopOpeBRepDS/TopOpeBRepDS_repvg.cxx
@@ -139,7 +139,7 @@ Standard_EXPORT void FDS_repvg2
 	  gp_Pnt2d uv; ok = FUN_tool_paronEF(E,pE,F1,uv); if (!ok) {it2.Next();continue;}
 	  Standard_Real factor = 0.789;
 	  TopOpeBRepTool_makeTransition MKT; 
-	  TopAbs_State stb = TopAbs_State::TopAbs_UNKNOWN,sta = TopAbs_State::TopAbs_UNKNOWN; 
+	  TopAbs_State stb = TopAbs_UNKNOWN,sta = TopAbs_UNKNOWN; 
 	  ok = MKT.Initialize(E,pbef,paft,pE, F1,uv, factor);
 	  if (ok) ok = MKT.SetRest(E1,pE1);
 	  if (ok) ok = MKT.MkTonE(stb,sta);


### PR DESCRIPTION
bcc32 does not allow '::' operator to be used with non class or namespace objects.
This change had been introduced in 90f47e1.
