### PR TITLE
Link TDataXtd_test against FWOSPlugin

### DIFF
--- a/test/TDataXtd_test/CMakeLists.txt
+++ b/test/TDataXtd_test/CMakeLists.txt
@@ -1,3 +1,9 @@
-IF (${PROJECT_NAME}_DATAEXCHANGE AND NOT ${PROJECT_NAME}_DISABLE_X11)
-    ADD_OCE_TEST(TDataXtd_test "TKCAF;TKXCAF")
-ENDIF (${PROJECT_NAME}_DATAEXCHANGE AND NOT ${PROJECT_NAME}_DISABLE_X11)
+IF (${PROJECT_NAME}_OCAF)
+    # This test will dlopen FWOSPlugin, we link against it to ensure that
+    # the library from the build tree is used.
+    ADD_OCE_TEST(TDataXtd_test "TKCAF;TKXCAF;FWOSPlugin")
+    FILE(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../src/StdResource" BuildPluginDir)
+    # Semi-colon is a delimiter in SET_TESTS_PROPERTIES and have to be escaped
+    STRING(REPLACE ";" "\\;" BuildPluginDir "${BuildPluginDir}")
+    SET_TESTS_PROPERTIES(TDataXtdTestSuite.testPattern PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_PluginUserDefaults=${BuildPluginDir}")
+ENDIF (${PROJECT_NAME}_OCAF)


### PR DESCRIPTION
This executable loads FWOSPlugin at run-time.  But plugins are not
installed at their final location when test is run, so a wrong
library may be loaded instead.  Link against this library to avoid
this mismatch.

Moreover set CSF_PluginDefaults and CSF_PluginUserDefaults environment
variable when running this test to load resource file from the build
tree.

This commit fixes issue #278.
