### PR TITLE
MinGW32 compatibility fixes.

### DIFF
--- a/inc/Standard_Atomic.hxx
+++ b/inc/Standard_Atomic.hxx
@@ -40,9 +40,6 @@
       long _InterlockedIncrement(long volatile* lpAddend);
       long _InterlockedDecrement(long volatile* lpAddend);
     }
-    // force intrinsic instead of WinAPI calls
-    #pragma intrinsic (_InterlockedIncrement)
-    #pragma intrinsic (_InterlockedDecrement)
   #else
     extern "C" {
       __declspec(dllimport) long __stdcall InterlockedIncrement ( long volatile *lpAddend);
@@ -51,6 +48,12 @@
     #define _InterlockedIncrement InterlockedIncrement
     #define _InterlockedDecrement InterlockedDecrement
   #endif
+#endif
+
+#if defined(_MSC_VER)
+  // force intrinsic instead of WinAPI calls
+  #pragma intrinsic (_InterlockedIncrement)
+  #pragma intrinsic (_InterlockedDecrement)
 #endif
 
 //! Increments atomically integer variable pointed by theValue

--- a/src/OSD/OSD_MemInfo.cxx
+++ b/src/OSD/OSD_MemInfo.cxx
@@ -24,8 +24,8 @@
 #if (defined(_WIN32) || defined(__WIN32__))
   #if defined(__MINGW32__)
     #define WIN32_WINNT 0x0500
-    #define WINVER 0x0500 
-  #endif  
+    #define WINVER 0x0500
+  #endif
   #include <windows.h>
   #include <winbase.h>
   #include <process.h>


### PR DESCRIPTION
Fixes for compile errors when using MinGW32:
1. Enabling non-intrinsic InterlockedIncrement and InterlockedDecrement.
2. MEMORYSTATUSEX struct is undefined until these defines are before #include &lt;windows.h&gt;:
# define WIN32_WINNT 0x0500
# define WINVER 0x0500
