### PR TITLE
Fixed build on ubuntu 12.10

### DIFF
--- a/src/Draw/Draw_VariableCommands.cxx
+++ b/src/Draw/Draw_VariableCommands.cxx
@@ -134,7 +134,7 @@ static void numsave(const Handle(Draw_Drawable3D)&d, ostream& OS)
   OS.precision(15);
   OS.width(30);
 #else
-  long form = OS.setf(ios::scientific);
+  std::ios_base::fmtflags form = OS.setf(ios::scientific);
   int  prec = OS.precision(15);
   int w = OS.width(30);
 #endif

--- a/src/DrawTrSurf/DrawTrSurf.cxx
+++ b/src/DrawTrSurf/DrawTrSurf.cxx
@@ -1766,7 +1766,7 @@ static void pntsave(const Handle(Draw_Drawable3D)&d, ostream& OS)
   OS.setf(ios::scientific,ios::floatfield);
   OS.precision(15);
 #else
-  long form = OS.setf(ios::scientific);
+  std::ios_base::fmtflags form = OS.setf(ios::scientific);
   std::streamsize prec = OS.precision(15);
 #endif
   gp_Pnt P = N->Point();
@@ -1828,7 +1828,7 @@ static void triasave(const Handle(Draw_Drawable3D)&d, ostream& OS)
   OS.setf(ios::scientific,ios::floatfield);
   OS.precision(15);
 #else
-  long form = OS.setf(ios::scientific);
+  std::ios_base::fmtflags form = OS.setf(ios::scientific);
   std::streamsize prec = OS.precision(15);
 #endif
   Poly::Write(T->Triangulation(),OS);
@@ -1869,7 +1869,7 @@ static void poly3dsave(const Handle(Draw_Drawable3D)&d, ostream& OS)
   OS.setf(ios::scientific,ios::floatfield);
   OS.precision(15);
 #else
-  long form = OS.setf(ios::scientific);
+  std::ios_base::fmtflags form = OS.setf(ios::scientific);
   std::streamsize prec = OS.precision(15);
 #endif
   Poly::Write(T->Polygon3D(),OS);
@@ -1909,7 +1909,7 @@ static void poly2dsave(const Handle(Draw_Drawable3D)&d, ostream& OS)
   OS.setf(ios::scientific, ios::floatfield);
   OS.precision(15);
 #else
-  long form = OS.setf(ios::scientific);
+  std::ios_base::fmtflags form = OS.setf(ios::scientific);
   std::streamsize prec = OS.precision(15);
 #endif
   Poly::Write(T->Polygon2D(),OS);

--- a/src/DrawTrSurf/DrawTrSurf_Point.cxx
+++ b/src/DrawTrSurf/DrawTrSurf_Point.cxx
@@ -196,7 +196,7 @@ void DrawTrSurf_Point::Dump(Standard_OStream& S) const
   S.setf(ios::scientific,ios::floatfield);
   S.precision(15);
 #else
-  long form = S.setf(ios::scientific);
+  std::ios_base::fmtflags form = S.setf(ios::scientific);
   std::streamsize prec = S.precision(15);
 #endif
   if (is3D)


### PR DESCRIPTION
This one fixes some type mismatch errors building on Ubuntu 12.10 -- gcc 4.7.2
