### PR TITLE
Ensure GeomLib::NormEstim won't last for ever

### DIFF
--- a/src/GeomLib/GeomLib.cxx
+++ b/src/GeomLib/GeomLib.cxx
@@ -2399,7 +2399,14 @@ Standard_Integer GeomLib::NormEstim(const Handle(Geom_Surface)& S,
 
   gp_Vec NAux = DU^DV;
   Standard_Real h1 = h;
-  while(NAux.SquareMagnitude() < aTol2) {
+
+  //Ensure that the following loop won't last for
+  //ever. If after 50 iterations the normal is still
+  //bad we just give up
+  int nbiter = 0;
+  int maxIter = 50;
+
+  while(NAux.SquareMagnitude() < aTol2 && nbiter <= maxIter) {
     h1 += h;
     if(AlongV) {
       Standard_Real v = UV.Y() + sign*h1;
@@ -2417,8 +2424,11 @@ Standard_Integer GeomLib::NormEstim(const Handle(Geom_Surface)& S,
 
     }
     NAux = DU^DV;
+    nbiter++;
   }
 
+  if(nbiter == maxIter)
+    return 3;
 
   Iso->D2(t, DummyPnt, Tang, DD);
 


### PR DESCRIPTION
This patch make the following program run in 0.01s instead of 80s. The created mesh have 132 triangles.

```
#include <BRepTools.hxx>
#include <iostream>
#include <BRep_Builder.hxx>
#include <BRepMesh_IncrementalMesh.hxx>
#include <BRep_Tool.hxx>
#include <Poly_Triangulation.hxx>
using namespace std;

int main()
{
    BRep_Builder bb;
    TopoDS_Face shape;
    TopLoc_Location loc;
    cout << BRepTools::Read(shape, "slowmesh.brep", bb) << endl;
    BRepTools::Clean(shape);
    BRepMesh_IncrementalMesh(shape, 5, false);
    const Handle(Poly_Triangulation) triangulation = BRep_Tool::Triangulation(shape, loc);
    cout << triangulation->NbTriangles() << endl;
    return 0;
}
```

The slowmesh.brep file. https://gist.github.com/9af35df566db197856c1
