### PR TITLE
Fix test/TDataXtd_test/CMakeLists.txt

### DIFF
--- a/test/TDataXtd_test/CMakeLists.txt
+++ b/test/TDataXtd_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-IF (${PROJECT_NAME}_OCAF)
+IF (${PROJECT_NAME}_DATAEXCHANGE AND NOT ${PROJECT_NAME}_DISABLE_X11)
     # This test will dlopen FWOSPlugin, we link against it to ensure that
     # the library from the build tree is used.
     ADD_OCE_TEST(TDataXtd_test "TKCAF;TKXCAF;FWOSPlugin")
@@ -6,4 +6,4 @@ IF (${PROJECT_NAME}_OCAF)
     # Semi-colon is a delimiter in SET_TESTS_PROPERTIES and have to be escaped
     STRING(REPLACE ";" "\\;" BuildPluginDir "${BuildPluginDir}")
     SET_TESTS_PROPERTIES(TDataXtdTestSuite.testPattern PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_PluginUserDefaults=${BuildPluginDir}")
-ENDIF (${PROJECT_NAME}_OCAF)
+ENDIF (${PROJECT_NAME}_DATAEXCHANGE AND NOT ${PROJECT_NAME}_DISABLE_X11)


### PR DESCRIPTION
It seems commit bc50e52 had been reverted by commit e9ad629, no idea
what happened.  Anyway, reapply bc50e52:

```
Run TDataXtd_test only if OCE_DISABLE_X11 option is not set

It depends on TKCAF and TKXCAF modules which are built only
if OCE_DISABLE_X11 is not set.

Moreover TKXCAF is built by DATA_EXCHANGE and not OCAF, so
we must check against DATA_EXCHANGE instead of OCAF.
```
