### PR TITLE
Fixes a range-check error in Units_Lexicon

### DIFF
--- a/src/Units/Units_Lexicon.cxx
+++ b/src/Units/Units_Lexicon.cxx
@@ -60,7 +60,7 @@ void Units_Lexicon::Creates(const Standard_CString afilename)
   char *Coeff = coeff ;
 #endif
   Standard_Integer fr;
-  Standard_Size i;
+  int i;  // Warning : don't use unsigned type here (or Standard_Size or size_t), else the while's below will cause an unsigned 0-wrap!
   Standard_Real value;
   Handle(Units_Token) token;
   struct stat buf;
@@ -86,7 +86,7 @@ void Units_Lexicon::Creates(const Standard_CString afilename)
   //for(i=0; i<=255; i++)line[i]=0;
 
   while(file.getline(line,255)) {
-    Standard_Size len = strlen( line ) ;
+    int len = (int) strlen( line ) ;
     if(len == 1) continue; //skl - ???
     for ( i = 0 ; i < 30 ; i++ ) {
       if ( i < len )


### PR DESCRIPTION
(this may be due to our warning fixes)
The int i var was wrapping (size_t i = 0; i--). In debug mode it works, in release mode it gives a range-check error.
I spotted this because there is the /GS flag active that does range checking in potentially dangerous code (like this is), so the test failed.

I don't really know the cause of this, but it may crash because because doing unsigned 0-1 is undefined behavior, and probably the optimizer does something to reorder things.
BTW, I don't know why these whiles don't result in an infinite execution if i goes to 0.
i>=0 returns false if i == UINT_MAX

Anyway , all test pass now :)
