### PR TITLE
Check compiler before including stdint.h

### DIFF
--- a/src/OSD/OSD_File.cxx
+++ b/src/OSD/OSD_File.cxx
@@ -845,7 +845,9 @@ Standard_Boolean OSD_File::IsExecutable()
 
 #include <stdio.h>
 #include <io.h>
+#if !defined (_MSC_VER) || (_MSC_VER >= 1600)
 #include <stdint.h>
+#endif
 #include <Standard_PCharacter.hxx>
 
 #ifndef _INC_TCHAR

--- a/src/OSD/OSD_FileNode.cxx
+++ b/src/OSD/OSD_FileNode.cxx
@@ -460,7 +460,9 @@ Standard_Integer OSD_FileNode::Error()const{
 #endif  // _INC_TCHAR
 
 #include <stdio.h>
+#if !defined (_MSC_VER) || (_MSC_VER >= 1600)
 #include <stdint.h>
+#endif
 
 #define TEST_RAISE( arg ) _test_raise (  fName, ( arg )  )
 #define RAISE( arg ) Standard_ProgramError :: Raise (  ( arg )  )

--- a/src/OSD/OSD_Process.cxx
+++ b/src/OSD/OSD_Process.cxx
@@ -235,7 +235,9 @@ Standard_Integer OSD_Process::Error()const{
 
 #include <OSD_WNT_1.hxx>
 #include <lmcons.h> /// pour UNLEN  ( see MSDN about GetUserName() )
+#if !defined (_MSC_VER) || (_MSC_VER >= 1600)
 #include <stdint.h>
+#endif
 
 void _osd_wnt_set_error ( OSD_Error&, OSD_WhoAmI, ... );
 

--- a/src/OSD/OSD_Thread.cxx
+++ b/src/OSD/OSD_Thread.cxx
@@ -132,7 +132,9 @@ void OSD_Thread::SetFunction (const OSD_ThreadFunction &func)
 //=============================================
 
 #ifdef WNT
+#if !defined (_MSC_VER) || (_MSC_VER >= 1600)
 #include <stdint.h>
+#endif
 #include <malloc.h>
 // On Windows the signature of the thread function differs from that on UNIX/Linux.
 // As we use the same definition of the thread function on all platforms (POSIX-like),

--- a/src/OSD/OSD_WNT_1.cxx
+++ b/src/OSD/OSD_WNT_1.cxx
@@ -20,7 +20,9 @@
 #include <OSD_WNT_1.hxx>
 
 #include <windowsx.h>
+#if !defined (_MSC_VER) || (_MSC_VER >= 1600)
 #include <stdint.h>
+#endif
 
 #ifndef min
 # define min(a, b)  (((a) < (b)) ? (a) : (b))

--- a/src/OSD/OSD_signal_WNT.cxx
+++ b/src/OSD/OSD_signal_WNT.cxx
@@ -204,7 +204,9 @@ _CRTIMP _se_translator_function __cdecl _set_se_translator(_se_translator_functi
 #include <process.h>
 #include <signal.h>
 #include <float.h>
+#if !defined (_MSC_VER) || (_MSC_VER >= 1600)
 #include <stdint.h>
+#endif
 
 static Standard_Boolean fMsgBox;
 static Standard_Boolean fFltExceptions;


### PR DESCRIPTION
I would have used a config.h option, but if I remember we want to support compilation without config.h
