### PR TITLE
Define class TColStd_DataMapOfIntegerListOfInteger

### DIFF
--- a/inc/BOP_SolidSolid.hxx
+++ b/inc/BOP_SolidSolid.hxx
@@ -37,6 +37,7 @@ class TopTools_ListOfShape;
 class BOP_ShellFaceSet;
 class TopoDS_Shape;
 class TopTools_DataMapOfShapeInteger;
+class TColStd_DataMapOfIntegerListOfInteger;
 class TColStd_IndexedMapOfInteger;
 
 


### PR DESCRIPTION
Commit 4597e04 changed signature of TakeOnSplit.
A new argument of class TColStd_DataMapOfIntegerListOfInteger was
introduced, but this class was not defined.
It compiled fine because source files include it directly, but
this class must be defined.
