### PR TITLE
Fix cpp syntax errors in inc/NCollection_Vec[234].hxx

### DIFF
--- a/inc/NCollection_Vec2.hxx
+++ b/inc/NCollection_Vec2.hxx
@@ -19,11 +19,13 @@
 #ifndef _NCollection_Vec2_H__
 #define _NCollection_Vec2_H__
 
+#include <cmath>
+
 //! Auxiliary macros to define couple of similar access components as vector methods.
 //! @return 2 components by their names in specified order
 #define NCOLLECTION_VEC_COMPONENTS_2D(theX, theY) \
-  const NCollection_Vec2<Element_t> theX##theY##() const { return NCollection_Vec2<Element_t>(theX##(), theY##()); } \
-  const NCollection_Vec2<Element_t> theY##theX##() const { return NCollection_Vec2<Element_t>(theY##(), theX##()); }
+  const NCollection_Vec2<Element_t> theX##theY() const { return NCollection_Vec2<Element_t>(theX(), theY()); } \
+  const NCollection_Vec2<Element_t> theY##theX() const { return NCollection_Vec2<Element_t>(theY(), theX()); }
 
 //! Defines the 2D-vector template.
 //! The main target for this class - to handle raw low-level arrays (from/to graphic driver etc.).

--- a/inc/NCollection_Vec3.hxx
+++ b/inc/NCollection_Vec3.hxx
@@ -25,12 +25,12 @@
 
 //! Auxiliary macros to define couple of similar access components as vector methods
 #define NCOLLECTION_VEC_COMPONENTS_3D(theX, theY, theZ) \
-  const NCollection_Vec3<Element_t> theX##theY##theZ##() const { return NCollection_Vec3<Element_t>(theX##(), theY##(), theZ##()); } \
-  const NCollection_Vec3<Element_t> theX##theZ##theY##() const { return NCollection_Vec3<Element_t>(theX##(), theZ##(), theY##()); } \
-  const NCollection_Vec3<Element_t> theY##theX##theZ##() const { return NCollection_Vec3<Element_t>(theY##(), theX##(), theZ##()); } \
-  const NCollection_Vec3<Element_t> theY##theZ##theX##() const { return NCollection_Vec3<Element_t>(theY##(), theZ##(), theX##()); } \
-  const NCollection_Vec3<Element_t> theZ##theY##theX##() const { return NCollection_Vec3<Element_t>(theZ##(), theY##(), theX##()); } \
-  const NCollection_Vec3<Element_t> theZ##theX##theY##() const { return NCollection_Vec3<Element_t>(theZ##(), theX##(), theY##()); }
+  const NCollection_Vec3<Element_t> theX##theY##theZ() const { return NCollection_Vec3<Element_t>(theX(), theY(), theZ()); } \
+  const NCollection_Vec3<Element_t> theX##theZ##theY() const { return NCollection_Vec3<Element_t>(theX(), theZ(), theY()); } \
+  const NCollection_Vec3<Element_t> theY##theX##theZ() const { return NCollection_Vec3<Element_t>(theY(), theX(), theZ()); } \
+  const NCollection_Vec3<Element_t> theY##theZ##theX() const { return NCollection_Vec3<Element_t>(theY(), theZ(), theX()); } \
+  const NCollection_Vec3<Element_t> theZ##theY##theX() const { return NCollection_Vec3<Element_t>(theZ(), theY(), theX()); } \
+  const NCollection_Vec3<Element_t> theZ##theX##theY() const { return NCollection_Vec3<Element_t>(theZ(), theX(), theY()); }
 
 //! Generic 3-components vector.
 //! To be used as RGB color pixel or XYZ 3D-point.

--- a/inc/NCollection_Vec4.hxx
+++ b/inc/NCollection_Vec4.hxx
@@ -19,6 +19,7 @@
 #ifndef _NCollection_Vec4_H__
 #define _NCollection_Vec4_H__
 
+#include <cstring>
 #include <NCollection_Vec3.hxx>
 
 //! Generic 4-components vector.


### PR DESCRIPTION
Add missing #include.

These header files are unused for now, this is why these errors did
not pop up earlier.
