### PR TITLE
Fix an OSD_Path constructor on unknown systems

### DIFF
--- a/src/OSD/OSD_Path.cxx
+++ b/src/OSD/OSD_Path.cxx
@@ -365,9 +365,10 @@ OSD_Path::OSD_Path(const TCollection_AsciiString& aDependentName,
      MacExtract(aDependentName,myDisk,myTrek,myName,myExtension);
      break;
   default:
-#ifndef DEB
-       cout << " WARNING WARNING : OSD Path for an Unknown SYSTEM : " << (Standard_Integer)todo << endl;
+#ifdef DEB
+     cout << " WARNING WARNING : OSD Path for an Unknown SYSTEM : " << (Standard_Integer)todo << endl;
 #endif 
+     UnixExtract(aDependentName,myNode,myUserName,myPassword,myTrek,myName,myExtension);
      break ;
  } 
 }


### PR DESCRIPTION
See https://buildd.debian.org/status/fetch.php?pkg=oce&arch=hurd-i386&ver=0.11-2&stamp=1355676025
several tests fail on Hurd:
    24 - IGESImportTestSuite.testImportIGES_1 (Failed)
    25 - STEPImportTestSuite.testImportAP203_1 (Failed)
    26 - STEPImportTestSuite.testImportAP203_2 (Failed)
    27 - STEPImportTestSuite.testImportAP214_1 (Failed)
    28 - STEPImportTestSuite.testImportAP214_2 (Failed)
    29 - STEPImportTestSuite.testImportAP214_3 (Failed)
    34 - TDataXtdTestSuite.testPattern (Failed)
    35 - UnitsAPITestSuite.testCurrentUnits (Failed)
    36 - UnitsAPITestSuite.testMDTVCurrentUnits (Failed)
because this OSD_Path constructor did nothing when system is unknown.
Use UnixExtract by default.
