### PR TITLE
FIXED: Draws an array with the color which is specified in the bound array.

### DIFF
--- a/src/OpenGl/OpenGl_PrimitiveArray.cxx
+++ b/src/OpenGl/OpenGl_PrimitiveArray.cxx
@@ -293,6 +293,7 @@ void OpenGl_PrimitiveArray::DrawArray (Tint theLightingModel,
       {
         for (i = n = 0; i < myPArray->num_bounds; ++i)
         {
+          if (pfc != NULL) glColor3fv (pfc[i].rgb);
           glDrawArrays (myDrawMode, n, myPArray->bounds[i]);
           n += myPArray->bounds[i];
         }


### PR DESCRIPTION
According to the comment of Graphic3d_ArrayOfPrimitives::AddBound
method, the bound color will be used when the &lt;hasBColors&gt;
contructor parameter is TRUE.
