### PR TITLE
Remove unused #include<Xw_Window.hxx> causing trouble on OSX with Cocoa

### DIFF
--- a/src/V3d/V3d_PositionLight.cxx
+++ b/src/V3d/V3d_PositionLight.cxx
@@ -46,9 +46,6 @@
 #include <gp_Pnt.hxx>
 #include <gp_Trsf.hxx>
 #include <TCollection_AsciiString.hxx>
-#ifdef WNT
-# include <WNT_Window.hxx>
-#endif
 
 V3d_PositionLight::V3d_PositionLight(const Handle(V3d_Viewer)& VM) : V3d_Light(VM) {
 }

--- a/src/V3d/V3d_SpotLight.cxx
+++ b/src/V3d/V3d_SpotLight.cxx
@@ -58,9 +58,6 @@
 #include <gp_Trsf.hxx>
 #include <TCollection_AsciiString.hxx>
 
-#ifdef WNT
-# include <WNT_Window.hxx>
-#endif
 
 
 V3d_SpotLight::V3d_SpotLight(const Handle(V3d_Viewer)& VM, const Standard_Real X, const Standard_Real Y, const Standard_Real Z, const V3d_TypeOfOrientation Direction, const Quantity_NameOfColor Name, const Standard_Real A1, const Standard_Real A2, const Standard_Real CN, const Standard_Real AN):V3d_PositionLight(VM) {


### PR DESCRIPTION
Fixes issue #370.
