### PR TITLE
Fix build failure on Mac OSX 10.5, posix_memalign was introduced in 10.6

### DIFF
--- a/src/Image/Image_PixMap.cxx
+++ b/src/Image/Image_PixMap.cxx
@@ -21,10 +21,10 @@
 
 #ifdef _MSC_VER
   #include <malloc.h>
-#elif (defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 1)
+#elif defined(HAVE_MM_MALLOC_H)
   #include <mm_malloc.h>
 #else
-  extern "C" int posix_memalign (void** thePtr, size_t theAlign, size_t theBytesCount);
+  #include <stdlib.h>
 #endif
 
 template<typename TypePtr>
@@ -33,15 +33,17 @@ inline TypePtr MemAllocAligned (const Standard_Size& theBytesCount,
 {
 #if defined(_MSC_VER)
   return (TypePtr )_aligned_malloc (theBytesCount, theAlign);
-#elif (defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 1)
+#elif defined(HAVE_MM_MALLOC_H)
   return (TypePtr )     _mm_malloc (theBytesCount, theAlign);
-#else
+#elif defined(HAVE_POSIX_MEMALIGN)
   void* aPtr;
   if (posix_memalign (&aPtr, theAlign, theBytesCount))
   {
     aPtr = NULL;
   }
   return (TypePtr )aPtr;
+#else
+  return (TypePtr ) malloc (theBytesCount);
 #endif
 }
 
@@ -49,7 +51,7 @@ inline void MemFreeAligned (void* thePtrAligned)
 {
 #if defined(_MSC_VER)
   _aligned_free (thePtrAligned);
-#elif (defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 1)
+#elif defined(HAVE_MM_MALLOC_H)
   _mm_free (thePtrAligned);
 #else
   free (thePtrAligned);


### PR DESCRIPTION
We fixed a related issue in 51e8674:
  Call _mm_malloc if mm_malloc.h header is found, otherwise call
  posix_memalign if this function was found, otherwise call malloc.

This patch had been dropped after 0.12 because of an incompatible change
with OCCT 6.6.0.
This commit modifies src/Image/Image_PixMap.cxx to match the version
in OCE 0.12.

Fixes issue #378.
