### PR TITLE
Link OCAFExport_test against FWOSPlugin and TKBin

### DIFF
--- a/test/OCAFExport_test/CMakeLists.txt
+++ b/test/OCAFExport_test/CMakeLists.txt
@@ -1,3 +1,10 @@
 IF (${PROJECT_NAME}_OCAF)
-    ADD_OCE_TEST(OCAFExport_test "TKCAF")
+    # This test will dlopen FWOSPlugin and TKBin, we link against them to ensure that
+    # libraries from the build tree are used.
+    ADD_OCE_TEST(OCAFExport_test "TKCAF;FWOSPlugin;TKBin")
+    FILE(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../src/StdResource" BuildPluginDir)
+    # Semi-colon is a delimiter in SET_TESTS_PROPERTIES and have to be escaped
+    STRING(REPLACE ";" "\\;" BuildPluginDir "${BuildPluginDir}")
+    SET_TESTS_PROPERTIES(OCAFExportTestSuite.testExportAscii PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_PluginUserDefaults=${BuildPluginDir}")
+    SET_TESTS_PROPERTIES(OCAFExportTestSuite.testExportNonAscii PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_PluginUserDefaults=${BuildPluginDir}")
 ENDIF (${PROJECT_NAME}_OCAF)


### PR DESCRIPTION
This is the same problem as in commit e9ad629, this test
loads FWOSPlugin and TKBin at run-time.  Since there is
currently no way to tell plugin directory at runtime, it is
simpler to directly link against these libraries.

Moreover set CSF_PluginDefaults and CSF_PluginUserDefaults environment
variable when running this test to load resource file from the build
tree.
