### PR TITLE
Remove implicit linking of the freetype library

### DIFF
--- a/src/Font/Font_FontMgr.cxx
+++ b/src/Font/Font_FontMgr.cxx
@@ -75,10 +75,6 @@ static const Font_FontMgr_FontAliasMapNode Font_FontMgr_MapOfFontsAliases[] =
   #include <windows.h>
   #include <stdlib.h>
 
-  #ifdef _MSC_VER
-    #pragma comment (lib, "freetype.lib")
-  #endif
-
   namespace
   {
 


### PR DESCRIPTION
a #pragma comment was left, always linking the release library even in debug configurations.
OCE handles linking using the cmake configuration.
