### PR TITLE
Fix OCAFExport_test failure

### DIFF
--- a/test/OCAFExport_test/CMakeLists.txt
+++ b/test/OCAFExport_test/CMakeLists.txt
@@ -5,6 +5,6 @@ IF (${PROJECT_NAME}_OCAF)
     FILE(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../src/StdResource" BuildPluginDir)
     # Semi-colon is a delimiter in SET_TESTS_PROPERTIES and have to be escaped
     STRING(REPLACE ";" "\\;" BuildPluginDir "${BuildPluginDir}")
-    SET_TESTS_PROPERTIES(OCAFExportTestSuite.testExportAscii PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_PluginUserDefaults=${BuildPluginDir}")
-    SET_TESTS_PROPERTIES(OCAFExportTestSuite.testExportNonAscii PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_PluginUserDefaults=${BuildPluginDir}")
+    SET_TESTS_PROPERTIES(OCAFExportTestSuite.testExportAscii PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_StandardDefaults=${BuildPluginDir}")
+    SET_TESTS_PROPERTIES(OCAFExportTestSuite.testExportNonAscii PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_StandardDefaults=${BuildPluginDir}")
 ENDIF (${PROJECT_NAME}_OCAF)


### PR DESCRIPTION
Also set CSF_StandardDefaults environment variable when
running these tests, it is also needed in order to
read src/StdResource/Standard file.
