### PR TITLE
Let CMake GUI display OCE_BUILD_TYPE as a combo box

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,13 +56,17 @@ endif(${CMAKE_SIZEOF_VOID_P} MATCHES "8")
 
 message(STATUS "Build ${BIT}bit")
 
-if (NOT MSVC)
+if(NOT CMAKE_CONFIGURATION_TYPES)
 	if( NOT DEFINED OCE_BUILD_TYPE )
-		set( OCE_BUILD_TYPE "Release" CACHE STRING "Build type" ) # By default set release build
+		set( OCE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Release Debug RelWithDebInfo MinSizeRel None" )
 	endif( NOT DEFINED OCE_BUILD_TYPE )
-	set( CMAKE_BUILD_TYPE ${OCE_BUILD_TYPE} CACHE INTERNAL "Build type,
-		immutable" FORCE )
-endif(NOT MSVC)
+	#  The "set_property(CACHE" capability first appeared in CMake version 2.8.0
+	#  We test against > 2.8 though, otherwise test is much less readable
+	if (${CMAKE_VERSION} VERSION_GREATER 2.8)
+		set_property(CACHE OCE_BUILD_TYPE PROPERTY STRINGS "Release" "Debug" "RelWithDebInfo" "MinSizeRel" "None")
+	endif (${CMAKE_VERSION} VERSION_GREATER 2.8)
+	set( CMAKE_BUILD_TYPE ${OCE_BUILD_TYPE} CACHE INTERNAL "Build type, immutable" FORCE )
+endif(NOT CMAKE_CONFIGURATION_TYPES)
 
 if(CMAKE_BUILD_TOOL STREQUAL "nmake")
 	set(NMAKE TRUE)


### PR DESCRIPTION
Apply the same trick as with OCE_MULTITHREAD_LIBRARY.
This applies only on generators working on a single configuration.
