### PR TITLE
TKQADraw module should be built when DRAW is on.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1189,11 +1189,7 @@ endif(OCE_DATAEXCHANGE)
 
 # DRAWEXE application
 if(OCE_DRAW)
-	if(OCE_TESTING)
 	process_module( "Draw" "" "TKDraw;TKTopTest;TKViewerTest;TKXSDRAW;TKDCAF;TKXDEDRAW;TKTObjDRAW;TKQADraw;DRAWEXE" )
-	else(OCE_TESTING)
-	process_module( "Draw" "" "TKDraw;TKTopTest;TKViewerTest;TKXSDRAW;TKDCAF;TKXDEDRAW;TKTObjDRAW;DRAWEXE" )
-	endif(OCE_TESTING)
 endif(OCE_DRAW)
 
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/adm/cmake/config/ProjectConfig.cmake.in


### PR DESCRIPTION
Fixes case (hpux) where oce_testing is not available (cmake v. 2.6)
but draw and upstream testing framework are available.
