### PR TITLE
HPUX template issue fix.

### DIFF
--- a/src/NCollection/NCollection_Array2.hxx
+++ b/src/NCollection/NCollection_Array2.hxx
@@ -65,7 +65,7 @@ template <class TheItemType> class NCollection_Array2
     { 
       myCurrent = 0;
       mySize    = theArray.Length();
-      myArray   = (NCollection_Array2 *) &theArray; 
+      myArray   = (NCollection_Array2<TheItemType> *) &theArray; 
     }
     //! Check end
     virtual Standard_Boolean More (void) const


### PR DESCRIPTION
This modification was not made hpux specific since the intend in
the rest of the file is to use specialization parameters in
template names.
