### PR TITLE
Take CSF_GraphicShr environment variable into account

### DIFF
--- a/src/Graphic3d/Graphic3d.cxx
+++ b/src/Graphic3d/Graphic3d.cxx
@@ -40,6 +40,10 @@ Handle(Graphic3d_GraphicDriver) Graphic3d::InitGraphicDriver (const Handle(Aspec
 
   TCollection_AsciiString aGraphicLibName;
 
+  const char *shr = getenv("CSF_GraphicShr");
+  if (shr != NULL) {
+    aGraphicLibName = shr;
+  } else {
 #ifdef OCE_DEFAULT_CSF_GraphicShr
   aGraphicLibName = OCE_DEFAULT_CSF_GraphicShr;
 #else
@@ -54,6 +58,7 @@ Handle(Graphic3d_GraphicDriver) Graphic3d::InitGraphicDriver (const Handle(Aspec
   aGraphicLibName = "libTKOpenGl.so";
 #endif
 #endif
+  }
 
   // Loading the library.
   OSD_SharedLibrary aSharedLibrary (aGraphicLibName.ToCString());


### PR DESCRIPTION
The handling of libTKOpenGl has been fully redesigned
in OCCT 6.6.0.  The CSF_GraphicShr environment variable
is now useless, it does nothing.

We added OCE_DEFAULT_CSF_GraphicShr a while back so that
libTKOpenGl is found at runtime without having to set
LD_LIBRARY_PATH.

But the drawback is that if there is a libTKOpenGl located
at OCE_DEFAULT_CSF_GraphicShr, it is not possible to
load a library located at another location.

Reinstate the usage of the CSF_GraphicShr environment in
order to allow overriding OCE_DEFAULT_CSF_GraphicShr.
