### PR TITLE
Revert f32f5d3, atomic operations are mandatory in multithread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,10 @@ else ()
 	set_directory_properties(PROPERTIES COMPILE_DEFINITIONS_DEBUG "_DEBUG")
 endif (OCE_ENABLE_DEB_FLAG)
 
+if(OCE_MULTITHREAD_LIBRARY STREQUAL "NONE")
+    add_definitions(-DIGNORE_NO_ATOMICS)
+endif (OCE_MULTITHREAD_LIBRARY STREQUAL "NONE")
+
 #
 # Check components dependencies
 #

--- a/src/Standard/Standard_Atomic.hxx
+++ b/src/Standard/Standard_Atomic.hxx
@@ -150,7 +150,7 @@ int Standard_Atomic_Decrement (volatile int* theValue)
 #else
 
 #ifndef IGNORE_NO_ATOMICS
-  #warning "Atomic operation isn't implemented for current platform!"
+  #error "Atomic operation isn't implemented for current platform!"
 #endif
 int Standard_Atomic_Increment (volatile int* theValue)
 {


### PR DESCRIPTION
In monothread, compile with -DIGNORE_NO_ATOMICS flag.
