### PR TITLE
Replace ASSERT_EQ(bool,bool) by ASSERT_TRUE/ASSERT_FALSE(bool)

### DIFF
--- a/test/STEPImport_test/STEPImport_test.cpp
+++ b/test/STEPImport_test/STEPImport_test.cpp
@@ -15,11 +15,11 @@ TEST(STEPImportTestSuite, testImportAP203_1)
     int nb_shapes = 0;
     for ( Standard_Integer n = 1; n <= nb_root; n++ ) {
         Standard_Boolean result = aReader.TransferRoot( n );
-        ASSERT_EQ(Standard_True,result);
+        ASSERT_TRUE(result);
         nb_shapes = aReader.NbShapes();
         if ( nb_shapes > 0 ) {
             TopoDS_Shape shape = aReader.Shape( n );
-            ASSERT_EQ(Standard_False,shape.IsNull());
+            ASSERT_FALSE(shape.IsNull());
             }
         }
 }
@@ -34,11 +34,11 @@ TEST(STEPImportTestSuite, testImportAP203_2)
     int nb_shapes = 0;
     for ( Standard_Integer n = 1; n <= nb_root; n++ ) {
         Standard_Boolean result = aReader.TransferRoot( n );
-        ASSERT_EQ(Standard_True,result);
+        ASSERT_TRUE(result);
         nb_shapes = aReader.NbShapes();
         if ( nb_shapes > 0 ) {
             TopoDS_Shape shape = aReader.Shape( n );
-            ASSERT_EQ(Standard_False,shape.IsNull());
+            ASSERT_FALSE(shape.IsNull());
             }
         }
 }
@@ -53,11 +53,11 @@ TEST(STEPImportTestSuite, testImportAP214_1)
     int nb_shapes = 0;
     for ( Standard_Integer n = 1; n <= nb_root; n++ ) {
         Standard_Boolean result = aReader.TransferRoot( n );
-        ASSERT_EQ(Standard_True,result);
+        ASSERT_TRUE(result);
         nb_shapes = aReader.NbShapes();
         if ( nb_shapes > 0 ) {
             TopoDS_Shape shape = aReader.Shape( n );
-            ASSERT_EQ(Standard_False,shape.IsNull());
+            ASSERT_FALSE(shape.IsNull());
             }
         }
 }
@@ -72,11 +72,11 @@ TEST(STEPImportTestSuite, testImportAP214_2)
     int nb_shapes = 0;
     for ( Standard_Integer n = 1; n <= nb_root; n++ ) {
         Standard_Boolean result = aReader.TransferRoot( n );
-        ASSERT_EQ(Standard_True,result);
+        ASSERT_TRUE(result);
         nb_shapes = aReader.NbShapes();
         if ( nb_shapes > 0 ) {
             TopoDS_Shape shape = aReader.Shape( n );
-            ASSERT_EQ(Standard_False,shape.IsNull());
+            ASSERT_FALSE(shape.IsNull());
             }
         }
 }
@@ -91,11 +91,11 @@ TEST(STEPImportTestSuite, testImportAP214_3)
     int nb_shapes = 0;
     for ( Standard_Integer n = 1; n <= nb_root; n++ ) {
         Standard_Boolean result = aReader.TransferRoot( n );
-        ASSERT_EQ(Standard_True,result);
+        ASSERT_TRUE(result);
         nb_shapes = aReader.NbShapes();
         if ( nb_shapes > 0 ) {
             TopoDS_Shape shape = aReader.Shape( n );
-            ASSERT_EQ(Standard_False,shape.IsNull());
+            ASSERT_FALSE(shape.IsNull());
             }
         }
 }


### PR DESCRIPTION
The former now raises gcc warnings:

```
  In file included from .../oce/test/gtest-1.7.0/include/gtest/gtest.h:1929:0,
                   from .../oce/test/STEPImport_test/STEPImport_test.cpp:4:
  .../oce/test/STEPImport_test/STEPImport_test.cpp: In member function ‘virtual void STEPImportTestSuite_testImportAP203_1_Test::TestBody()’:
  .../oce/test/gtest-1.7.0/include/gtest/internal/gtest-internal.h:133:55: warning: converting ‘false’ to pointer type for argument 1 of ‘char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)’ [-Wconversion-null]
       (sizeof(::testing::internal::IsNullLiteralHelper(x)) == 1)
                                                         ^
  .../oce/test/gtest-1.7.0/include/gtest/gtest_pred_impl.h:77:52: note: in definition of macro ‘GTEST_ASSERT_’
     if (const ::testing::AssertionResult gtest_ar = (expression)) \
                                                      ^
  .../oce/test/gtest-1.7.0/include/gtest/gtest_pred_impl.h:166:3: note: in expansion of macro ‘GTEST_PRED_FORMAT2_’
     GTEST_PRED_FORMAT2_(pred_format, v1, v2, GTEST_FATAL_FAILURE_)
     ^
  .../oce/test/gtest-1.7.0/include/gtest/gtest.h:1993:3: note: in expansion of macro ‘ASSERT_PRED_FORMAT2’
     ASSERT_PRED_FORMAT2(::testing::internal:: \
     ^
  .../oce/test/gtest-1.7.0/include/gtest/gtest.h:1994:32: note: in expansion of macro ‘GTEST_IS_NULL_LITERAL_’
                         EqHelper<GTEST_IS_NULL_LITERAL_(expected)>::Compare, \
                                  ^
  .../oce/test/gtest-1.7.0/include/gtest/gtest.h:2011:32: note: in expansion of macro ‘GTEST_ASSERT_EQ’
   # define ASSERT_EQ(val1, val2) GTEST_ASSERT_EQ(val1, val2)
                                  ^
  .../oce/test/STEPImport_test/STEPImport_test.cpp:22:13: note: in expansion of macro ‘ASSERT_EQ’
               ASSERT_EQ(Standard_False,shape.IsNull());
               ^
```
