### PR TITLE
Improve travis-ci usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,8 @@ script: cmake -DOCE_ENABLE_DEB_FLAG:BOOL=OFF
         if test -x /usr/bin/getconf; then echo "Starting build with -j$(/usr/bin/getconf _NPROCESSORS_ONLN) ...";
         make -j$(/usr/bin/getconf _NPROCESSORS_ONLN); else make; fi
 after_script: make test
+branches:
+  only:
+    - master
+    - /^review/
+


### PR DESCRIPTION
Precompiled headers are enabled in order to speed up builds.
Predependencies are installed in before_install target, and all components are now compiled.
Only compile master and review/\* branches to not abuse travis-ci resources.
