### PR TITLE
Made library output path absolute when using MinGw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -857,8 +857,6 @@ if(WIN32)
 	if(MSVC) # The compiler used is MSVC
 		message(STATUS "Found MSVC compiler: ${MSVC} ${MSVC_VERSION}")
 		set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin/)
-	elseif (BORLAND) # The compiler used is BORLAND
-		set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/win${BIT}/bin/${CMAKE_BUILD_TYPE})
 	else()
 		IF (MINGW)
 			message(STATUS "Found MINGW compiler: ${MINGW}")


### PR DESCRIPTION
With this commit OCE can be compiled with MinGw64 again.
