### PR TITLE
ApproxAFunc2Var: numerical bug triggered by compiler optimization

### DIFF
--- a/src/AdvApp2Var/AdvApp2Var_ApproxAFunc2Var.cxx
+++ b/src/AdvApp2Var/AdvApp2Var_ApproxAFunc2Var.cxx
@@ -293,10 +293,12 @@ void AdvApp2Var_ApproxAFunc2Var::InitGrid(const Standard_Integer NbInt)
   Standard_Real deltu = (myLastParInU-myFirstParInU)/NbInt,
                 deltv = (myLastParInV-myFirstParInV)/NbInt;
   for (iint=1;iint<=NbInt-1;iint++) {
-    Result.UpdateInU(myFirstParInU+iint*deltu);
-    Constraints.UpdateInU(myFirstParInU+iint*deltu);
-    Result.UpdateInV(myFirstParInV+iint*deltv);
-    Constraints.UpdateInV(myFirstParInV+iint*deltv);
+    Standard_Real u = myFirstParInU + iint * deltu;
+    Standard_Real v = myFirstParInV + iint * deltv;
+    Result.UpdateInU(u);
+    Constraints.UpdateInU(u);
+    Result.UpdateInV(v);
+    Constraints.UpdateInV(v);
   }
   myResult = Result;
   myConstraints = Constraints;


### PR DESCRIPTION
Here Result and Constraints UpdateInX method expect exactly the same value.
Because of the compiler optimization the evaluation of
myFirstParInU+iint*deltu may be different between Result and Constraints
update call.
