### PR TITLE
Fix Standard_Construction_Error exception in BOP

### DIFF
--- a/src/BOPTools/BOPTools_AlgoTools.cxx
+++ b/src/BOPTools/BOPTools_AlgoTools.cxx
@@ -1872,6 +1872,7 @@ Standard_Boolean FindPointInFace(const TopoDS_Edge& aE,
     aPOut = aProjPL.NearestPoint();
     //
     gp_Vec aV(aP, aPOut);
+    if (aV.XYZ().Modulus() <= gp::Resolution()) break;
     aDB.SetXYZ(aV.XYZ());
   } while (aDist>Precision::Angular() && --aNbItMax);
   //


### PR DESCRIPTION
gp_Vec.setXYZ() may be called on a null vector within
BOPTools::FindPointInFace, which throws an exception if
they have not been disabled.

Fix #485.
