### PR TITLE
Fix race condition when building with USE_PCH and COPY_HEADERS_BUILD

### DIFF
--- a/adm/cmake/BuildToolkit.cmake
+++ b/adm/cmake/BuildToolkit.cmake
@@ -334,6 +334,14 @@ if( TOOLKIT_HEADER_FILES AND OCE_COPY_HEADERS_BUILD )
 
 endif()
 
+if(TARGET ${TOOLKIT}_gch)
+	foreach(tkit ${TOOLKIT_DEPENDS})
+		if(TARGET copy_${tkit}_headers)
+			add_dependencies(${TOOLKIT}_gch copy_${tkit}_headers)
+		endif()
+	endforeach(tkit ${TOOLKIT_DEPENDS})
+endif(TARGET ${TOOLKIT}_gch)
+
 ###########
 # INSTALL #
 ###########


### PR DESCRIPTION
See for instance travis build failure for job 257.5.
