### PR TITLE
Fix build failures with Mesa 10.3.1

### DIFF
--- a/src/OpenGl/OpenGl_GlCore11.hxx
+++ b/src/OpenGl/OpenGl_GlCore11.hxx
@@ -36,6 +36,7 @@
 
 // exclude modern definitions and system-provided glext.h, should be defined before gl.h inclusion
 #define GL_GLEXT_LEGACY
+#define GLX_GLXEXT_LEGACY
 
 // include main OpenGL header provided with system
 #if defined(__APPLE__) && !defined(MACOSX_USE_GLX)


### PR DESCRIPTION
Newer Mesa looks buggy, several errors like this one are reported:
 /usr/include/GL/glxext.h:480:143: error: ‘GLintptr’ has not been declared
 typedef void ( *PFNGLXCOPYBUFFERSUBDATANVPROC) (Display *dpy, GLXContext readCtx, GLXContext writeCtx, GLenum readTarget, GLenum writeTarget, GLintptr readOffset, GLintptr writeOffset, GLsizeiptr size);
Work around this issue by defining GLX_GLXEXT_LEGACY.

Fix issue #534.
