### PR TITLE
Fixed file stream opening errors with MinGw

### DIFF
--- a/src/BinLDrivers/BinLDrivers_DocumentRetrievalDriver.cxx
+++ b/src/BinLDrivers/BinLDrivers_DocumentRetrievalDriver.cxx
@@ -181,6 +181,8 @@ void BinLDrivers_DocumentRetrievalDriver::Read
   // Open the file stream
 #ifdef _MSC_VER
   ifstream anIS ((const wchar_t*) theFileName.ToExtString(), ios::in | ios::binary);
+#elif (defined(__MINGW32__) || defined(__MINGW64__))
+  ifstream anIS (aFileName.ToCString(), ios::in | ios::binary);
 #else
   ifstream anIS (aFileName.ToCString());
 #endif


### PR DESCRIPTION
OCC 6.8.0 has introduced a problem when MinGw is used as compiler: binary OCAF files cannot be read in correctly, if they contain shape sets (please check "0026414: Cannot read in shape set from OCAF binary file" in OCC issue tracker for further information).