### PR TITLE
Appveyor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-Travis-CI Build Status :
+Travis-CI:
 [![Build Status](https://travis-ci.org/tpaviot/oce.png?branch=master)](https://travis-ci.org/tpaviot/oce)
+Appveyor:
+[![Build Status](https://ci.appveyor.com/api/projects/status/wq74bifo9lojmxsj?svg=true)](https://ci.appveyor.com/project/tpaviot/oce)
 
 ## About
 
@@ -53,6 +55,8 @@ We use the following online resources:
        http://groups.google.com/group/oce-dev/about
   * Travic-CI
        https://travis-ci.org/tpaviot/oce
+  * Appveyor
+       https://ci.appveyor.com/project/tpaviot/oce
 
 Just ask @tpaviot (tpaviot@gmail.com) or @dbarbier (bouzim@gmail.com) for a
 request regarding write access to the repository.

--- a/appveyor-scripts/make-oce-msvc.bat
+++ b/appveyor-scripts/make-oce-msvc.bat
@@ -1,0 +1,30 @@
+cd C:\projects\oce-win-bundle
+mkdir cmake-build
+cd cmake-build
+cmake -DBUNDLE_BUILD_FREEIMAGE:BOOL=OFF ^
+      -DBUNDLE_BUILD_FREETYPE:BOOL=ON ^
+      -DBUNDLE_BUILD_GL2PS:BOOL=OFF ^
+      -DBUNDLE_SHARED_LIBRARIES:BOOL=ON ^
+      -DOCE_WIN_BUNDLE_INSTALL_DIR=C:\oce-win-bundle ^
+      -G "%generator%" ..
+msbuild /m:4 /verbosity:quiet /clp:ErrorsOnly /p:Configuration=Release oce-win-bundle.sln
+msbuild /m:4 /verbosity:quiet /clp:ErrorsOnly /p:Configuration=Release INSTALL.vcxproj
+
+cd C:\projects\oce
+mkdir cmake-build
+cd cmake-build
+cmake -DOCE_VISUALISATION:BOOL=ON -DOCE_DATAEXCHANGE:BOOL=ON -DOCE_OCAF:BOOL=ON ^
+      -DOCE_WITH_GL2PS:BOOL=OFF ^
+      -DOCE_WITH_FREEIMAGE:BOOL=OFF ^
+      -DOCE_TESTING:BOOL=OFF ^
+      -DOCE_MULTITHREAD_LIBRARY=NONE ^
+      -DFREETYPE_INCLUDE_DIR_freetype2=C:\oce-win-bundle\include\freetype ^
+      -DFREETYPE_INCLUDE_DIR_ft2build=C:\oce-win-bundle\include\freetype ^
+      -DFREETYPE_LIBRARY=C:\oce-win-bundle\%ARCH%\lib\freetype.lib ^
+      -DFREEIMAGE_INCLUDE_DIR=C:\oce-win-bundle\include\FreeImage ^
+      -DFREEIMAGE_LIBRARY=C:\oce-win-bundle\%ARCH%\lib\FreeImage.lib ^
+      -DFREEIMAGEPLUS_LIBRARY=C:\oce-win-bundle\%ARCH%\lib\FreeImagePlus.lib ^
+      -DOCE_INSTALL_PREFIX=C:\oce-%oce_version% ^
+      -G "%generator%" ..
+msbuild /m:4 /verbosity:quiet /p:Configuration=%configuration% oce.sln
+msbuild /m:4 /verbosity:quiet /p:Configuration=%configuration% INSTALL.vcxproj

--- a/appveyor-scripts/make-oce-msys.sh
+++ b/appveyor-scripts/make-oce-msys.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -e
+cd `dirname "$0"`/..
+if [ "$Arch" = "Win32" ]; then
+  echo 'C:\MinGW\ /MinGW' > /etc/fstab
+elif [ "$Arch" = "i686" ]; then
+  f=i686-4.9.3-release-win32-sjlj-rt_v4-rev0.7z
+  if ! [ -e $f ]; then
+    curl -LsSO http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/4.9.3/threads-win32/sjlj/$f
+  fi
+  7z x $f > /dev/null
+  mv mingw32 /MinGW
+else
+  f=x86_64-5.1.0-release-win32-seh-rt_v4-rev0.7z
+  if ! [ -e $f ]; then
+    curl -LsSO http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/5.1.0/threads-win32/seh/$f
+  fi
+  7z x $f > /dev/null
+  mv mingw64 /MinGW
+fi
+g++ -v
+#
+# Build oce dependencies
+#
+cd /c/projects/oce-win-bundle
+mkdir cmake-build
+cd cmake-build
+cmake -DBUNDLE_BUILD_FREEIMAGE:BOOL=OFF \
+      -DBUNDLE_BUILD_FREETYPE:BOOL=ON \
+      -DBUNDLE_BUILD_GL2PS:BOOL=OFF \
+      -DBUNDLE_SHARED_LIBRARIES:BOOL=ON \
+      -DOCE_WIN_BUNDLE_INSTALL_DIR=c:\\oce-win-bundle \
+      -G'MSYS Makefiles' ..
+mingw32-make -j4
+mingw32-make install
+#
+# Then make oce
+#
+cd /c/projects/oce
+mkdir cmake-build
+cd cmake-build
+cmake -DOCE_VISUALISATION:BOOL=ON \
+      -DOCE_DATAEXCHANGE:BOOL=OFF -DOCE_OCAF:BOOL=OFF \
+      -DOCE_WITH_GL2PS:BOOL=OFF \
+      -DOCE_WITH_FREEIMAGE:BOOL=OFF \
+      -DOCE_TESTING:BOOL=ON \
+      -DOCE_COPY_HEADERS_BUILD:BOOL=ON \
+      -DFREETYPE_INCLUDE_DIR_freetype2=C:\\oce-win-bundle\\include\\freetype \
+      -DFREETYPE_INCLUDE_DIR_ft2build=C:\\oce-win-bundle\\include\\freetype \
+      -DFREETYPE_LIBRARY=C:\\projects\\oce-win-bundle\\cmake-build\\freetype.cmake\\libfreetype.dll \
+      -DFREEIMAGE_INCLUDE_DIR=C:\\oce-win-bundle\include\\FreeImage \
+      -DFREEIMAGE_LIBRARY=C:\\oce-win-bundle\\$Arch\\lib\\FreeImage.lib \
+      -DFREEIMAGEPLUS_LIBRARY=C:\\oce-win-bundle\\$Arch\\lib\\FreeImagePlus.lib \
+      -DOCE_INSTALL_PREFIX=C:\\oce-0.17.1-dev \
+      -G'MSYS Makefiles' ..
+mingw32-make -j4
+mingw32-make install > /dev/null
+#
+# Finally run tests
+#
+export PATH=$PATH:/c/MinGW/bin:/c/oce-0.17.1-dev/$Arch/bin:/c/MinGW/bin:
+mingw32-make test

--- a/appveyor-scripts/make-oce-msys.sh
+++ b/appveyor-scripts/make-oce-msys.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
 cd `dirname "$0"`/..
+echo "$Arch"
 if [ "$Arch" = "Win32" ]; then
   echo 'C:\MinGW\ /MinGW' > /etc/fstab
 elif [ "$Arch" = "i686" ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ branches:
 
 shallow_clone: true 
 
-cache:
+#cache:
 #  - i686-4.9.3-release-win32-sjlj-rt_v4-rev0.7z
 #  - x86_64-5.1.0-release-win32-seh-rt_v4-rev0.7z
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ configuration:
 branches:
   only:
     - master
-    - review/*
+    - /^review/
 
 shallow_clone: true 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,83 @@
+version: oce-0.17.1-dev.{build}
+
+environment:
+  oce_version: 0.17.1-dev
+  matrix:
+    - generator: "Visual Studio 12"
+      Arch: Win32
+      Compiler: MSVC2013
+    - generator: "Visual Studio 12 Win64"
+      Arch: Win64
+      Compiler: MSVC2013
+    - generator: "Visual Studio 14"
+      Arch: Win32
+      Compiler: MSVC2015
+    - generator: "Visual Studio 14 Win64"
+      Arch : Win64
+      Compiler: MSVC2015
+    - generator: "MSYS Makefiles"  # MinGW-w64 gcc-5.1.0 64 bit
+      Arch : Win64
+      Compiler: MinGW64-gcc-5.1.0
+    - generator: "MSYS Makefiles"  # MinGW-w64 gcc-4.9.3 32 bit
+      Arch: i686
+      Compiler: MinGW-gcc-4.9.3
+    - generator: "MSYS Makefiles"  # MinGW-w64 gcc-4.8.1 32 bit that comes with appveyor
+      Arch : Win32
+      Compiler: MinGW-gcc-4.8.1
+
+matrix:
+  allow_failures:
+    - generator: "MSYS Makefiles"
+      Arch : Win32
+      Compiler: MinGW-gcc-4.8.1
+
+configuration:
+  #- Debug
+  - RelWithDebInfo
+
+branches:
+  only:
+    - master
+    - review/*
+
+shallow_clone: true 
+
+cache:
+  - i686-4.9.3-release-win32-sjlj-rt_v4-rev0.7z
+  - x86_64-5.1.0-release-win32-seh-rt_v4-rev0.7z
+
+# scripts that are called at very beginning, before repo cloning
+init:
+
+before_build:
+
+# scripts that run after cloning repository
+install:
+  - cmd: git clone -q --branch=master https://github.com/QbProg/oce-win-bundle.git C:\projects\oce-win-bundle
+
+build_script:
+  - cmd: if "%generator%" == "MSYS Makefiles" (C:\MinGW\msys\1.0\bin\sh --login /c/projects/oce/appveyor-scripts/make-oce-msys.sh)
+      else (CALL C:\projects\oce\appveyor-scripts\make-oce-msvc.bat)
+
+after_build:
+  - cmd: 7z a oce-%oce_version%.%Arch%.%Compiler%.zip C:\oce-%oce_version% > nul
+  - cmd: dir oce-%oce_version%.%Arch%.%Compiler%.zip
+
+artifacts:
+  - path: oce-%oce_version%.%Arch%.%Compiler%.zip
+
+test: off  # to avoid discovering tests
+
+#
+# The following section automatically uploads artifacts
+# whenever a tag is created on the master branch.
+#
+deploy:
+  - provider: GitHub
+    auth_token:
+      secure: +HE8jHwECbKpIVHeydBVMBskoHh//glZWNo9oCLPvOtLiY3MAO75zPISuwPD/ctW
+    artifact: oce-%oce_version%.%Arch%.%Compiler%.zip
+    draft: true
+    on:
+      branch: master
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,11 +40,11 @@ branches:
     - master
     - /^review/
 
-shallow_clone: true 
+#shallow_clone: true 
 
-#cache:
-#  - i686-4.9.3-release-win32-sjlj-rt_v4-rev0.7z
-#  - x86_64-5.1.0-release-win32-seh-rt_v4-rev0.7z
+cache:
+  - i686-4.9.3-release-win32-sjlj-rt_v4-rev0.7z -> appveyor.yml
+  - x86_64-5.1.0-release-win32-seh-rt_v4-rev0.7z -> appveyor.yml
 
 # scripts that are called at very beginning, before repo cloning
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,8 +43,8 @@ branches:
 shallow_clone: true 
 
 cache:
-  - i686-4.9.3-release-win32-sjlj-rt_v4-rev0.7z
-  - x86_64-5.1.0-release-win32-seh-rt_v4-rev0.7z
+#  - i686-4.9.3-release-win32-sjlj-rt_v4-rev0.7z
+#  - x86_64-5.1.0-release-win32-seh-rt_v4-rev0.7z
 
 # scripts that are called at very beginning, before repo cloning
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,15 @@ version: oce-0.17.1-dev.{build}
 environment:
   oce_version: 0.17.1-dev
   matrix:
+    - generator: "MSYS Makefiles"  # MinGW-w64 gcc-4.8.1 32 bit that comes with appveyor
+      Arch: Win32
+      Compiler: MinGW-gcc-4.8.1
+    - generator: "MSYS Makefiles"  # MinGW-w64 gcc-4.9.3 32 bit
+      Arch: i686
+      Compiler: MinGW-gcc-4.9.3
+    - generator: "MSYS Makefiles"  # MinGW-w64 gcc-5.1.0 64 bit
+      Arch: Win64
+      Compiler: MinGW64-gcc-5.1.0
     - generator: "Visual Studio 12"
       Arch: Win32
       Compiler: MSVC2013
@@ -13,22 +22,13 @@ environment:
       Arch: Win32
       Compiler: MSVC2015
     - generator: "Visual Studio 14 Win64"
-      Arch : Win64
+      Arch: Win64
       Compiler: MSVC2015
-    - generator: "MSYS Makefiles"  # MinGW-w64 gcc-5.1.0 64 bit
-      Arch : Win64
-      Compiler: MinGW64-gcc-5.1.0
-    - generator: "MSYS Makefiles"  # MinGW-w64 gcc-4.9.3 32 bit
-      Arch: i686
-      Compiler: MinGW-gcc-4.9.3
-    - generator: "MSYS Makefiles"  # MinGW-w64 gcc-4.8.1 32 bit that comes with appveyor
-      Arch : Win32
-      Compiler: MinGW-gcc-4.8.1
 
 matrix:
   allow_failures:
     - generator: "MSYS Makefiles"
-      Arch : Win32
+      Arch: Win32
       Compiler: MinGW-gcc-4.8.1
 
 configuration:


### PR DESCRIPTION
This is a first attempts for appveyor-ci support. So far:

* msvc and mingw compilers are supported, both in defferent versions

* appveyor jobs are limited to 40mn. As a consequence, MinGW builds, which are much slower, are restricted to the FOUNDATION and MODEL frameworks. MSVC builds support all frameworks

* cmake tests are run only for MinGW builds. Enabling OCE_TESTING with MSVC fails

* msvc2015 fails to compile because FreeImage does not support this compiler.
