### PR TITLE
Appveyor support, MinGw fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-Travis-CI Build Status :
+Travis-CI:
 [![Build Status](https://travis-ci.org/tpaviot/oce.png?branch=master)](https://travis-ci.org/tpaviot/oce)
+Appveyor:
+[![Build Status](https://ci.appveyor.com/api/projects/status/wq74bifo9lojmxsj?svg=true)](https://ci.appveyor.com/project/tpaviot/oce)
 
 ## About
 
@@ -53,6 +55,8 @@ We use the following online resources:
        http://groups.google.com/group/oce-dev/about
   * Travic-CI
        https://travis-ci.org/tpaviot/oce
+  * Appveyor
+       https://ci.appveyor.com/project/tpaviot/oce
 
 Just ask @tpaviot (tpaviot@gmail.com) or @dbarbier (bouzim@gmail.com) for a
 request regarding write access to the repository.

--- a/appveyor-scripts/make-oce-msvc.bat
+++ b/appveyor-scripts/make-oce-msvc.bat
@@ -1,0 +1,12 @@
+cd C:\projects\oce
+mkdir cmake-build
+cd cmake-build
+cmake -DOCE_VISUALISATION:BOOL=ON -DOCE_DATAEXCHANGE:BOOL=ON -DOCE_OCAF:BOOL=ON ^
+      -DOCE_WITH_GL2PS:BOOL=OFF ^
+      -DOCE_WITH_FREEIMAGE:BOOL=OFF ^
+      -DOCE_TESTING:BOOL=OFF ^
+      -DOCE_MULTITHREAD_LIBRARY=NONE ^
+      -DOCE_INSTALL_PREFIX=C:\oce-%oce_version% ^
+      -G "%generator%" ..
+msbuild /m:4 /verbosity:quiet /p:Configuration=%configuration% oce.sln
+msbuild /m:4 /verbosity:quiet /p:Configuration=%configuration% INSTALL.vcxproj

--- a/appveyor-scripts/make-oce-msys.sh
+++ b/appveyor-scripts/make-oce-msys.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -e
+cd `dirname "$0"`/..
+if [ "$ARCH" = Win32 ]; then
+  echo 'C:\MinGW\ /MinGW' > /etc/fstab
+elif [ "$ARCH" = i686 ]; then 
+  f=i686-4.9.3-release-posix-dwarf-rt_v4-rev1.7z
+  if ! [ -e $f ]; then
+    echo "Downloading $f"
+    curl -LsSO http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/4.9.3/threads-posix/dwarf/$f
+  fi
+  7z x $f > /dev/null
+  echo "Extracting $f"
+  mv mingw32 /MinGW
+else
+  f=x86_64-5.2.0-release-posix-seh-rt_v4-rev0.7z
+  if ! [ -e $f ]; then
+    echo "Downloading $f"
+    curl -LsSO http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/5.2.0/threads-posix/seh/$f
+  fi
+  echo "Extracting $f"
+  7z x $f > /dev/null
+  mv mingw64 /MinGW
+fi
+g++ -v
+# make oce
+cd /c/projects/oce
+mkdir cmake-build
+cd cmake-build
+cmake -DOCE_VISUALISATION:BOOL=ON \
+      -DOCE_DATAEXCHANGE:BOOL=OFF -DOCE_OCAF:BOOL=OFF \
+      -DOCE_WITH_GL2PS:BOOL=ON \
+      -DOCE_WITH_FREEIMAGE:BOOL=OFF \
+      -DOCE_TESTING:BOOL=ON \
+      -DOCE_COPY_HEADERS_BUILD:BOOL=ON \
+      -DOCE_INSTALL_PREFIX=C:\\oce-0.17.1-dev \
+      -G'MSYS Makefiles' ..
+mingw32-make -j4
+mingw32-make install > /dev/null
+#
+# Finally run tests
+#
+export PATH=$PATH:/c/MinGW/bin:/c/oce-0.17.1-dev/$ARCH/bin:/c/MinGW/bin:
+mingw32-make test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,78 @@
+version: oce-0.17.1-dev.{build}
+
+environment:
+  oce_version: 0.17.1-dev
+  matrix:
+    - generator: "MSYS Makefiles"
+      Compiler: MinGW-gcc-4.8.1
+      ARCH: "Win32"
+    - generator: "MSYS Makefiles"
+      ARCH: "i686"
+      Compiler: MinGW-gcc-4.9.3
+    - generator: "MSYS Makefiles"
+      ARCH: "Win64"
+      Compiler: MinGW64-gcc-5.2.0
+    - generator: "Visual Studio 12"
+      ARCH: "Win32"
+      Compiler: "MSVC2013"
+    - generator: "Visual Studio 12 Win64"
+      ARCH: "Win64"
+      Compiler: "MSVC2013"
+    - generator: "Visual Studio 14"
+      ARCH: "Win32"
+      Compiler: "MSVC2015"
+    - generator: "Visual Studio 14 Win64"
+      ARCH: "Win64"
+      Compiler: "MSVC2015"
+
+cache:
+  - i686-4.9.3-release-posix-dwarf-rt_v4-rev1.7z
+  - x86_64-5.2.0-release-posix-seh-rt_v4-rev0.7z
+
+configuration:
+  #- Debug
+  - RelWithDebInfo
+
+branches:
+  only:
+    - master
+    - /^review/
+
+shallow_clone: true 
+
+# scripts that are called at very beginning, before repo cloning
+init:
+
+before_build:
+
+# scripts that run after cloning repository
+install:
+  - cmd: CALL FetchBundle.bat
+  #- cmd: git clone -q --branch=master https://github.com/QbProg/oce-win-bundle.git C:\projects\oce-win-bundle
+
+build_script:
+  - cmd: if "%generator%" == "MSYS Makefiles" (C:\MinGW\msys\1.0\bin\sh --login /c/projects/oce/appveyor-scripts/make-oce-msys.sh)
+      else (CALL C:\projects\oce\appveyor-scripts\make-oce-msvc.bat)
+
+after_build:
+  - cmd: 7z a oce-%oce_version%.%ARCH%.%Compiler%.zip C:\oce-%oce_version% > nul
+  - cmd: dir oce-%oce_version%.%ARCH%.%Compiler%.zip
+
+artifacts:
+  - path: oce-%oce_version%.%ARCH%.%Compiler%.zip
+
+test: off  # to avoid discovering tests
+
+#
+# The following section automatically uploads artifacts
+# whenever a tag is created on the master branch.
+#
+deploy:
+  - provider: GitHub
+    auth_token:
+      secure: +HE8jHwECbKpIVHeydBVMBskoHh//glZWNo9oCLPvOtLiY3MAO75zPISuwPD/ctW
+    artifact: oce-%oce_version%.%ARCH%.%Compiler%.zip
+    draft: true
+    on:
+      branch: master
+      appveyor_repo_tag: true

--- a/src/MeshVS/MeshVS_MeshPrsBuilder.cxx
+++ b/src/MeshVS/MeshVS_MeshPrsBuilder.cxx
@@ -56,6 +56,11 @@
 #include <NCollection_Map.hxx>
 #include <NCollection_Vector.hxx>
 
+#if defined(__MINGW32__)
+  #ifndef alloca
+  #define alloca __builtin_alloca 
+  #endif
+#endif
 //================================================================
 // Function : Constructor MeshVS_MeshPrsBuilder
 // Purpose  :

--- a/src/NCollection/NCollection_UBTreeFiller.hxx
+++ b/src/NCollection/NCollection_UBTreeFiller.hxx
@@ -28,7 +28,7 @@
 // MinGw defines rand_r in stdlib.h only in newer versions and only if _POSIX
 // or _POSIX_THREAD_SAFE_FUNCTIONS is defined. Therefore we paste the
 // definition from MinGw64 with g++ 5.1.0 here.
-#if defined(__MINGW64__)
+#if defined(__MINGW64__) || defined(__MINGW32__)
   #ifndef rand_r
   #define rand_r(__seed) (__seed == __seed ? rand () : rand ())
   #endif


### PR DESCRIPTION
This branch adds support for appveyor-ci builds on Windows, for Mingw and msvc both in 32 and 64 bit modes.

More over, this branch fixes 2 issues for Mingw32.

See https://ci.appveyor.com/project/tpaviot/oce
