### PR TITLE
Fix package errors on Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
       env: OCE_USE_PCH=ON  OCE_COPY_HEADERS_BUILD=OFF
 
 before_install:
+  - sudo apt-get update -q
   - sudo apt-get install tcl8.5-dev tk8.5-dev libgl2ps-dev libfreeimage-dev libtbb-dev
 #  Needed to run OCCT tests in parallel
   - sudo apt-get install tclthread


### PR DESCRIPTION
Many Travis builds have been failing lately with package errors. Travis recommends updating package lists before building (https://docs.travis-ci.com/user/installing-dependencies/#Installing-Ubuntu-packages), and this seems to help with those errors (it will take a few PRs to see if it goes away completely). In any case, adding this hurts nothing and only adds 9 seconds to build time. Ref #590