### PR TITLE
Fix MinGW32 build on Appveyor

### DIFF
--- a/appveyor-scripts/make-oce-msys.sh
+++ b/appveyor-scripts/make-oce-msys.sh
@@ -2,7 +2,7 @@
 set -e
 cd `dirname "$0"`/..
 if [ "$ARCH" = Win32 ]; then
-  echo 'C:\MinGW\ /MinGW' > /etc/fstab
+  PATH=$PATH:/c/MinGW/bin
 elif [ "$ARCH" = i686 ]; then 
   f=i686-4.9.3-release-posix-dwarf-rt_v4-rev1.7z
   if ! [ -e $f ]; then


### PR DESCRIPTION
The Appveyor build for plain MinGW was not finding g++.exe; put in a line to add C:\MinGW\bin to the path.