### PR TITLE
[VTK-fix] Replace obsolete vtkFloatingPointType

### DIFF
--- a/src/IVtkTools/IVtkTools_ShapePicker.cxx
+++ b/src/IVtkTools/IVtkTools_ShapePicker.cxx
@@ -74,14 +74,14 @@ float IVtkTools_ShapePicker::GetTolerance( ) const
 // Purpose: Convert display coordinates to world coordinates
 //============================================================================
 bool IVtkTools_ShapePicker::convertDisplayToWorld (vtkRenderer         *theRenderer,
-                                                   vtkFloatingPointType theDisplayCoord[3],
-                                                   vtkFloatingPointType theWorldCoord[3])
+                                                   double theDisplayCoord[3],
+                                                   double theWorldCoord[3])
 {
   // Convert the selection point into world coordinates.
   theRenderer->SetDisplayPoint (theDisplayCoord[0], theDisplayCoord[1], theDisplayCoord[2]);
   theRenderer->DisplayToWorld();
 
-  vtkFloatingPointType* const aCoords = theRenderer->GetWorldPoint();
+  double* const aCoords = theRenderer->GetWorldPoint();
   if (aCoords[3] == 0.0)
   {
     return false;

--- a/src/IVtkTools/IVtkTools_ShapePicker.hxx
+++ b/src/IVtkTools/IVtkTools_ShapePicker.hxx
@@ -124,8 +124,8 @@ protected:
 
   //! Convert display coordinates to world coordinates
   static bool convertDisplayToWorld (vtkRenderer *theRenderer,
-                                     vtkFloatingPointType theDisplayCoord[3],
-                                     vtkFloatingPointType theWorldCoord[3] );
+                                     double theDisplayCoord[3],
+                                     double theWorldCoord[3] );
 
 private: // not copyable
   IVtkTools_ShapePicker (const IVtkTools_ShapePicker&);

--- a/src/IVtkVTK/IVtkVTK_View.cxx
+++ b/src/IVtkVTK/IVtkVTK_View.cxx
@@ -149,7 +149,7 @@ bool IVtkVTK_View::DisplayToWorld (const gp_XY& theDisplayPnt, gp_XYZ& theWorldP
   myRenderer->SetDisplayPoint (theDisplayPnt.X(), theDisplayPnt.Y(), 0.0);
   myRenderer->DisplayToWorld();
 
-  vtkFloatingPointType* const aCoords = myRenderer->GetWorldPoint();
+  double* const aCoords = myRenderer->GetWorldPoint();
   if (aCoords[3] == 0.0) // Point at infinity in homogeneous coordinates
   {
     return false;


### PR DESCRIPTION
vtkFloatingPointType has always been equivalent to double, but they
removed this typedef/define years ago apparently. In the current API,
these functions specify doubles:
http://www.vtk.org/doc/nightly/html/classvtkViewport.html (vtkRenderer
is a derived class of vtkViewport and the member functions in question
are not overridden in vtkRenderer). Ref #598