### PR TITLE
Review/prepare 0.17.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,7 @@ matrix:
   - compiler: gcc
     env: OCE_USE_PCH=ON  OCE_COPY_HEADERS_BUILD=OFF
   - compiler: gcc
-    env: OCE_USE_PCH=OFF OCE_COPY_HEADERS_BUILD=OFF
-  - compiler: gcc
     env: OCE_USE_PCH=ON  OCE_COPY_HEADERS_BUILD=ON
-  - compiler: gcc
-    env: OCE_USE_PCH=OFF OCE_COPY_HEADERS_BUILD=ON
   - compiler: gcc
     env: OCE_USE_PCH=ON OCE_COPY_HEADERS_BUILD=ON OCE_MULTITHREAD_LIBRARY=OPENMP
   - compiler: gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,12 @@
 project(OCE)
 
 set(OCE_VERSION_MAJOR 0)
-set(OCE_VERSION_MINOR 18)
+set(OCE_VERSION_MINOR 17)
 # OCE_VERSION_PATCH is used for bugfixes releases only
 # (uncomment following line)
-set(OCE_VERSION_PATCH)
+set(OCE_VERSION_PATCH 2)
 #  Empty for official releases, set to -dev, -rc1, etc for development releases
-set(OCE_VERSION_DEVEL -dev)
+set(OCE_VERSION_DEVEL)
 
 # bugfix release: add ${OCE_VERSION_PATCH} to OCE_VERSION
 set(OCE_VERSION ${OCE_VERSION_MAJOR}.${OCE_VERSION_MINOR}${OCE_VERSION_DEVEL})

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,25 @@
+### Version 0.17.2 - May 2016
+
+This version is binary compatible with 0CE 0.17 and OCE 0.17.1
+
+* Fix VTK6.2 support
+
+* Fixed typo in BRepGProp_Sinert wich leads to wrong inertia matrix
+computationOCE_USE_STATIC_MSVC_RUNTIME advanced option to use static version of the
+
+* Workaround clang optimizations for null references
+
+* IntCurveSurface_Polygon::Init() improvement
+
+* Check distance between points before line creation
+
+* Replace obsolete vtkFloatingPointType typedef/define with double
+
+* Fixed crash on OS X due to clang compiler errors
+
+Users who contributed to this release:
+  Jacob Abel, Julien Finet, Thomas Paviot, Martin Siggel
+
 ### Version 0.17.1 - January 2016
 
 This version is binary compatible with 0CE 0.17.


### PR DESCRIPTION
This release includes the following changes:

* Fix VTK6.2 support

* Fixed typo in BRepGProp_Sinert wich leads to wrong inertia matrix
computationOCE_USE_STATIC_MSVC_RUNTIME advanced option to use static version of the

* Workaround clang optimizations for null references

* IntCurveSurface_Polygon::Init() improvement

* Check distance between points before line creation

* Replace obsolete vtkFloatingPointType typedef/define with double

* Fixed crash on OS X due to clang compiler errors
