### PR TITLE
0027385: assertion in static initializer in a Windows GUI application

### DIFF
--- a/src/OSD/OSD_Environment.cxx
+++ b/src/OSD/OSD_Environment.cxx
@@ -348,14 +348,9 @@ void OSD_Environment :: Reset () {
 
 }  // end OSD_Environment :: Reset
 
-void OSD_Environment :: Perror () {
-
- if (  ErrorPrefix ()  )
-
-  (  *ErrorStream ()  ) << TEXT( '\'' ) << myName.ToCString () << TEXT( "' - " );
-
- myError.Perror ();
-
+void OSD_Environment :: Perror ()
+{
+  myError.Perror ();
 }  // end OSD_Environment :: Perror
 
 Standard_Integer OSD_Environment :: Error () const {

--- a/src/OSD/OSD_Error.cxx
+++ b/src/OSD/OSD_Error.cxx
@@ -455,9 +455,6 @@ typedef struct _error_table {
 
                } ERROR_TABLE;
 
-static int      fPrefix     = 1;
-static ostream* errorStream = &cerr;
-
 static ERROR_TABLE commErrorTable [] = {
 
  { ERROR_INVALID_FUNCTION,      ERR_INVAL       },
@@ -571,14 +568,9 @@ OSD_Error :: OSD_Error () :
 
 void OSD_Error :: Perror () {
 
-  if (errorStream == NULL)
-    return;
-
  Standard_Character buff[ 32 ];
  Standard_CString   ptr;
 
- if ( fPrefix ) {
- 
   lstrcpy (  buff, "Error ( "  );
 
   switch ( myCode ) {
@@ -651,12 +643,9 @@ void OSD_Error :: Perror () {
 
   lstrcat ( buff, ptr );
   lstrcat (  buff, " )"  );
-  ( *errorStream ) << buff;
+  std::cerr << buff;
  
- }  // end if ( fPrefix . . . )
-
- TCollection_ExtendedString aMessageW(myMessage);
- ( *errorStream ) << L": " << (const wchar_t*)aMessageW.ToExtString () << endl << flush;
+ std::cerr << myMessage.ToCString() << std::endl << std::flush;
 
 }  // end OSD_Error :: Perror
 
@@ -739,41 +728,10 @@ Standard_Boolean OSD_Error :: Failed () const {
 
 }  // end OSD_Error :: Failed
 
-void OSD_Error :: Reset () {
-
- myErrno = ERROR_SUCCESS; 
- if (errorStream != NULL)
- {
-   ( *errorStream ).clear ();
-   ( *errorStream ).seekp ( 0 );
-   ( *errorStream ).clear ();
- }
-
+void OSD_Error :: Reset ()
+{
+  myErrno = ERROR_SUCCESS;
 }  // end OSD_Error :: Reset
-
-void SetErrorStream ( ostream* errStream ) {
-
- errorStream = errStream;
-
-}  // end SetErrorStream
-
-void EnablePrefix ( int fEnable ) {
-
- fPrefix = fEnable;
-
-}  // end EnablePrefix
-
-int ErrorPrefix ( void ) {
-
- return fPrefix;
-
-}  // end ErrorPrefix
-
-ostream* ErrorStream ( void ) {
-
- return errorStream;
-
-}  // end ErrorStream
 
 static Standard_Integer _get_comm_error ( DWORD dwCode ) {
 

--- a/src/OSD/OSD_WNT.hxx
+++ b/src/OSD/OSD_WNT.hxx
@@ -29,10 +29,4 @@
 #  endif
 # endif  // OSDAPI
 
-void     OSDAPI SetErrorStream ( ostream* );
-//ostream* OSDAPI ErrorStream    ( void     );
-ostream OSDAPI *ErrorStream    ( void     );    // for VisualAge
-void     OSDAPI EnablePrefix   ( int      );
-int      OSDAPI ErrorPrefix    ( void     );
-
 #endif  // __OSD_WNT_HXX

--- a/src/UnitsAPI/UnitsAPI.cxx
+++ b/src/UnitsAPI/UnitsAPI.cxx
@@ -31,13 +31,6 @@ static Units_UnitsSystem LocalSystemUnits,SILocalSystemUnits,MDTVLocalSystemUnit
 static TCollection_AsciiString rstring;
 static UnitsAPI_SystemUnits localSystem = UnitsAPI_SI;
 static UnitsAPI_SystemUnits currentSystem = UnitsAPI_DEFAULT;
-static OSD_Environment env1("CSF_UnitsLexicon");
-static OSD_Environment env2("CSF_UnitsDefinition");
-#ifdef WNT
-static OSD_Environment env3("CSF_CurrentUnits");
-static OSD_Environment env4("CSF_MDTVCurrentUnits");
-#endif
-
 
 //=======================================================================
 //function : CheckLoading
@@ -47,6 +40,7 @@ static OSD_Environment env4("CSF_MDTVCurrentUnits");
 void UnitsAPI::CheckLoading (const UnitsAPI_SystemUnits aSystemUnits)
 {
   if( currentSystem != aSystemUnits || CurrentUnits.IsNull()) {
+    OSD_Environment env1("CSF_UnitsLexicon");
     TCollection_AsciiString slexiconfile(env1.Value());
     if( slexiconfile.Length() > 0 )
       Units::LexiconFile(slexiconfile.ToCString());
@@ -66,6 +60,7 @@ void UnitsAPI::CheckLoading (const UnitsAPI_SystemUnits aSystemUnits)
 	Standard_NoSuchObject::Raise("environment variable CSF_UnitsLexicon undefined");
       }
     }
+    OSD_Environment env2("CSF_UnitsDefinition");
     TCollection_AsciiString sunitsfile(env2.Value());
     if( sunitsfile.Length() > 0 )
       Units::UnitsFile(sunitsfile.ToCString());
@@ -92,6 +87,7 @@ void UnitsAPI::CheckLoading (const UnitsAPI_SystemUnits aSystemUnits)
         currentSystem = UnitsAPI_SI; 
         if( SICurrentUnits.IsNull() ) {
 #ifdef WNT
+          OSD_Environment env3("CSF_CurrentUnits");
           TCollection_AsciiString csfcurrent (env3.Value());
           if( csfcurrent.Length() > 0 )
                 SICurrentUnits = new Resource_Manager(csfcurrent.ToCString());
@@ -108,6 +104,7 @@ void UnitsAPI::CheckLoading (const UnitsAPI_SystemUnits aSystemUnits)
         currentSystem = UnitsAPI_MDTV; 
         if( MDTVCurrentUnits.IsNull() )  {
 #ifdef WNT
+          OSD_Environment env4("CSF_MDTVCurrentUnits");
           TCollection_AsciiString csfmdtvcurrent (env4.Value());
           if( csfmdtvcurrent.Length() > 0 )
                 MDTVCurrentUnits = new Resource_Manager(csfmdtvcurrent.ToCString());


### PR DESCRIPTION
Useless global pointer to cerr is removed from OSD_Error, along with methods supporting its customization (Windows-only).
Global accessors to environment variables are replaced by locals in UnitsAPI.cxx.