### PR TITLE
Various changes related to a 0.18 port.

### DIFF
--- a/src/AdvApp2Var/AdvApp2Var_SysBase.hxx
+++ b/src/AdvApp2Var/AdvApp2Var_SysBase.hxx
@@ -122,7 +122,7 @@ public:
 private:
 #endif
 
-  enum {
+  enum alloctype_enum {
     static_allocation = 0, /* indicates static allocation, currently not used */
     heap_allocation   = 1  /* indicates heap allocation */
   };

--- a/src/BOPCol/BOPCol_VectorOfInteger.hxx
+++ b/src/BOPCol/BOPCol_VectorOfInteger.hxx
@@ -15,8 +15,4 @@
 #ifndef BOPCol_VectorOfInteger_HeaderFile
 #define BOPCol_VectorOfInteger_HeaderFile
 
-#include <BOPCol_Array1.hxx>
-
-typedef BOPCol_Array1<Standard_Integer> BOPDS_VectorOfInteger;
-
 #endif

--- a/src/BRepBuilderAPI/BRepBuilderAPI_FastSewing.hxx
+++ b/src/BRepBuilderAPI/BRepBuilderAPI_FastSewing.hxx
@@ -301,6 +301,6 @@ private:
   FS_VARStatuses myStatusList;
 };
 
-#endif // _BRepBuilderAPI_FastSewing_HeaderFile
-
 DEFINE_STANDARD_HANDLE(BRepBuilderAPI_FastSewing, Standard_Transient)
+
+#endif // _BRepBuilderAPI_FastSewing_HeaderFile

--- a/src/BRepGProp/BRepGProp_Gauss.hxx
+++ b/src/BRepGProp/BRepGProp_Gauss.hxx
@@ -14,6 +14,8 @@
 #ifndef _BRepGProp_Gauss_HeaderFile
 #define _BRepGProp_Gauss_HeaderFile
 
+#include <BRepGProp_Face.hxx>
+#include <BRepGProp_Domain.hxx>
 #include <NCollection_Handle.hxx>
 #include <NCollection_Array1.hxx>
 

--- a/src/BRepLib/BRepLib_CheckCurveOnSurface.lxx
+++ b/src/BRepLib/BRepLib_CheckCurveOnSurface.lxx
@@ -12,6 +12,9 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
+#include <Geom_Curve.hxx>
+#include <Geom2d_Curve.hxx>
+
 //=======================================================================
 //function : Curve
 //purpose  : 

--- a/src/Graphic3d/Graphic3d_TransModeFlags.hxx
+++ b/src/Graphic3d/Graphic3d_TransModeFlags.hxx
@@ -18,7 +18,7 @@
 
 typedef Standard_Integer Graphic3d_TransModeFlags;
 
-enum {
+enum Graphic3d_TransModeFlags_Enum {
   Graphic3d_TMF_None               = 0x0000,
   Graphic3d_TMF_PanPers            = 0x0001,
   Graphic3d_TMF_ZoomPers           = 0x0002,

--- a/src/Graphic3d/Graphic3d_ZLayerId.hxx
+++ b/src/Graphic3d/Graphic3d_ZLayerId.hxx
@@ -21,7 +21,7 @@ typedef Standard_Integer Graphic3d_ZLayerId;
 //! This enumeration defines the list of predefined layers, which can not be removed (but settings can be overridden).
 //! Custom layers might be added with positive index (>= 1) if standard list is insufficient for application needs;
 //! these layers will be displayed on top of predefined ones.
-enum
+enum Graphic3d_ZLayerId_Enum
 {
   Graphic3d_ZLayerId_UNKNOWN = -1, //!< identifier for invalid ZLayer
   Graphic3d_ZLayerId_Default =  0, //!< default Z-layer for main presentations

--- a/src/IntTools/IntTools_SurfaceRangeSampleMapHasher.lxx
+++ b/src/IntTools/IntTools_SurfaceRangeSampleMapHasher.lxx
@@ -13,6 +13,8 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
+#include <IntTools_SurfaceRangeSample.hxx>
+
 inline Standard_Integer IntTools_SurfaceRangeSampleMapHasher::HashCode(const IntTools_SurfaceRangeSample& K,
 								       const Standard_Integer Upper) { 
 //   return (((K.GetDepthU() % Upper) ^ (K.GetDepthV() % Upper)) % Upper);

--- a/src/MeshVS/MeshVS_BuilderPriority.hxx
+++ b/src/MeshVS/MeshVS_BuilderPriority.hxx
@@ -18,7 +18,7 @@
 
 typedef Standard_Integer MeshVS_BuilderPriority;
 
-enum
+enum MeshVS_BuilderPriority_Enum
 {
   MeshVS_BP_Mesh       =  5,
   MeshVS_BP_NodalColor = 10,

--- a/src/MeshVS/MeshVS_DisplayModeFlags.hxx
+++ b/src/MeshVS/MeshVS_DisplayModeFlags.hxx
@@ -18,7 +18,7 @@
 
 typedef Standard_Integer MeshVS_DisplayModeFlags;
 
-enum
+enum MeshVS_DisplayModeFlags_Enum
 {
   MeshVS_DMF_WireFrame             = 0x0001,
   MeshVS_DMF_Shading               = 0x0002,

--- a/src/NIS/NIS_Triangulated.hxx
+++ b/src/NIS/NIS_Triangulated.hxx
@@ -55,7 +55,7 @@ class NIS_Triangulated : public NIS_InteractiveObject
    * e.g., Triangulation+Line. Line and Segments are not mixable, their mix is
    * treated as Line only.
    */
-  enum {
+  enum PresentationType {
     Type_None          =  0,
     Type_Loop          =  1,  //!< modifier to Line
     Type_Line          =  2,

--- a/src/STEPConstruct/STEPConstruct_PointHasher.lxx
+++ b/src/STEPConstruct/STEPConstruct_PointHasher.lxx
@@ -11,6 +11,8 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
+#include <gp_Pnt.hxx>
+
 //=======================================================================
 //function : HashCode
 //purpose  : 

--- a/src/SelectMgr/SelectMgr_RectangularFrustum.hxx
+++ b/src/SelectMgr/SelectMgr_RectangularFrustum.hxx
@@ -127,7 +127,7 @@ private:
   void cacheVertexProjections (SelectMgr_RectangularFrustum* theFrustum);
 
 private:
-  enum { LeftTopNear, LeftTopFar,
+  enum Position_Enum { LeftTopNear, LeftTopFar,
          LeftBottomNear, LeftBottomFar,
          RightTopNear, RightTopFar,
          RightBottomNear, RightBottomFar };

--- a/src/SelectMgr/SelectMgr_SelectingVolumeManager.hxx
+++ b/src/SelectMgr/SelectMgr_SelectingVolumeManager.hxx
@@ -152,7 +152,7 @@ public:
   Standard_EXPORT gp_Pnt GetFarPnt() const;
 
 private:
-  enum { Frustum, FrustumSet, VolumeTypesNb };       //!< Defines the amount of available selecting volumes
+  enum Selecting_Volumes_Enum { Frustum, FrustumSet, VolumeTypesNb };       //!< Defines the amount of available selecting volumes
 
   NCollection_Handle<SelectMgr_BaseFrustum> mySelectingVolumes[VolumeTypesNb];      //!< Array of selecting volumes
   Standard_Boolean                          myToAllowOverlap;      //!< Defines if partially overlapped entities will me detected or not

--- a/src/TDF/TDF_LabelNode.hxx
+++ b/src/TDF/TDF_LabelNode.hxx
@@ -31,7 +31,7 @@ class TDF_Label;
 
 #define KEEP_LOCAL_ROOT
 
-enum {
+enum TDF_LabelNodeMsk_Enum {
   TDF_LabelNodeImportMsk = (int) 0x80000000, // Because the sign bit (HP).
   TDF_LabelNodeAttModMsk = 0x40000000,
   TDF_LabelNodeMayModMsk = 0x20000000,


### PR DESCRIPTION
I've committed most of these changes separately in case you want to keep some and ignore others.   (perhaps the arbitrary enum names?).   In conjunction with a matching pull-request on PythonOCC-generator, I was able to build PythonOCC 0.18.
