### PR TITLE
Fix issue of raise exception when sweep along with cornered wire.

### DIFF
--- a/src/BRepFill/BRepFill_Sweep.cxx
+++ b/src/BRepFill/BRepFill_Sweep.cxx
@@ -673,7 +673,7 @@ static TopoDS_Edge BuildEdge(Handle(Geom_Curve)& C3d,
 //  P2  = BT.Pnt(VL);
   P2  = BRep_Tool::Pnt(VL);
 //  Tol2 = BT.Tolerance(VF);
-  Tol2 = BRep_Tool::Tolerance(VF);
+  Tol2 = BRep_Tool::Tolerance(VL);
   Tol = Max(Tol1, Tol2);
 
   if (VF.IsSame(VL) || 


### PR DESCRIPTION
Maybe forget to recover correct code after test.