### PR TITLE
Visualization, Font_FontMgr - do not look for fonts.dir on OS X

### DIFF
--- a/src/Font/Font_FontMgr.cxx
+++ b/src/Font/Font_FontMgr.cxx
@@ -35,7 +35,7 @@ struct Font_FontMgr_FontAliasMapNode
 static const Font_FontMgr_FontAliasMapNode Font_FontMgr_MapOfFontsAliases[] =
 {
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 
   { "Courier"                  , "Courier New"    , Font_FA_Regular },
   { "Times-Roman"              , "Times New Roman", Font_FA_Regular  },
@@ -115,9 +115,14 @@ static const Font_FontMgr_FontAliasMapNode Font_FontMgr_MapOfFontsAliases[] =
       "ttc",
       "pfa",
       "pfb",
+    #ifdef __APPLE__
+      // Datafork TrueType (OS X), obsolete
+      //"dfont",
+    #endif
       NULL
     };
 
+  #if !defined(__ANDROID__) && !defined(__APPLE__)
     // X11 configuration file in plain text format (obsolete - doesn't exists in modern distributives)
     static Standard_CString myFontServiceConf[] = {"/etc/X11/fs/config",
                                                    "/usr/X11R6/lib/X11/fs/config",
@@ -125,6 +130,7 @@ static const Font_FontMgr_FontAliasMapNode Font_FontMgr_MapOfFontsAliases[] =
                                                    NULL
                                                   };
 
+  #endif                                          
   #ifdef __APPLE__
     // default fonts paths in Mac OS X
     static Standard_CString myDefaultFontsDirs[] = {"/System/Library/Fonts",
@@ -377,6 +383,7 @@ void Font_FontMgr::InitFontDataBase()
 #else
 
   NCollection_Map<TCollection_AsciiString> aMapOfFontsDirs;
+#if !defined(__ANDROID__) && !defined(__APPLE__)
   const OSD_Protection aProtectRead (OSD_R, OSD_R, OSD_R, OSD_R);
 
   // read fonts directories from font service config file (obsolete)
@@ -434,6 +441,7 @@ void Font_FontMgr::InitFontDataBase()
     aFile.Close();
   }
 
+#endif
   // append default directories
   for (Standard_Integer anIter = 0; myDefaultFontsDirs[anIter] != NULL; ++anIter)
   {
@@ -454,7 +462,7 @@ void Font_FontMgr::InitFontDataBase()
   for (NCollection_Map<TCollection_AsciiString>::Iterator anIter (aMapOfFontsDirs);
        anIter.More(); anIter.Next())
   {
-  #ifdef __ANDROID__
+  #if defined(__ANDROID__) || defined(__APPLE__)
     OSD_Path aFolderPath (anIter.Value());
     for (OSD_FileIterator aFileIter (aFolderPath, "*"); aFileIter.More(); aFileIter.Next())
     {


### PR DESCRIPTION
Font_FontMgr::InitFontDataBase() now uses the same approach on OS X as on Android
ignoring fonts.dir files which are non used on these systems.

Backport occt upstream commit [0027505]. See
http://git.dev.opencascade.org/gitweb/?p=occt.git;a=commitdiff;h=264abd72f2508894ff6d514f2d9ff5c2443656f8;hp=e5260e1dfa44d1ca7adcdc0b04b3dd7506ffa103

See related issue on pythonocc-core https://github.com/tpaviot/pythonocc-core/issues/439