### PR TITLE
Update for vtk 8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,7 +354,7 @@ if(OCE_VISUALISATION AND OCE_WITH_VTK)
 	find_package(VTK QUIET COMPONENTS vtkCommonCore vtkInteractionStyle vtkIOExport vtkIOLegacy)
 
 	# Now that we know we have a VTK version available, we call find_package with the correct rendering backend.
-	if(VTK_VERSION_MAJOR EQUAL 7 AND VTK_RENDERING_BACKEND)
+	if( NOT(VTK_VERSION_MAJOR LESS 7) AND VTK_RENDERING_BACKEND)
 		# In VTK 7, the rendering backend is exported in the variable VTK_RENDERING_BACKEND
 		find_package(VTK QUIET COMPONENTS vtkRendering${VTK_RENDERING_BACKEND} vtkCommonCore vtkInteractionStyle vtkIOExport vtkIOLegacy)
 	else()


### PR DESCRIPTION
Condition should be 'at least for vtk version = 7'. Use the 'NOT LESS' formalism beacause 'GREATER_THAN' is only available since CMake 3.7