### PR TITLE
fix build errors with glibc 2.26+ due to missing xlocale.h (issue #675)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -616,6 +616,7 @@ if (NOT WIN32)
 	# compilation anywhere in OCE
 	include(CheckIncludeFile)
 	check_include_file(strings.h HAVE_STRINGS_H)
+	check_include_file(xlocale.h HAVE_XLOCALE_H)
 	include(CheckIncludeFileCXX)
 	check_include_file_cxx(mm_malloc.h HAVE_MM_MALLOC_H)
 	check_include_file_cxx(atomic.h OCE_HAVE_ATOMIC_H)

--- a/src/Standard/Standard_CLocaleSentry.hxx
+++ b/src/Standard/Standard_CLocaleSentry.hxx
@@ -20,21 +20,6 @@
 
 #include <locale.h>
 
-#ifndef HAVE_XLOCALE_H
-  //! "xlocale.h" available in Mac OS X and glibc (Linux) for a long time as an extension
-  //! and become part of POSIX since '2008.
-  //! Notice that this is impossible to test (_POSIX_C_SOURCE >= 200809L)
-  //! since POSIX didn't declared such identifier.
-  #if defined(__APPLE__)
-    #define HAVE_XLOCALE_H
-  #endif
-
-  //! We check _GNU_SOURCE for glibc extensions here and it is always defined by g++ compiler.
-  #if defined(_GNU_SOURCE) && !defined(__ANDROID__)
-    #define HAVE_XLOCALE_H
-  #endif
-#endif // ifndef HAVE_LOCALE_H
-
 #ifdef HAVE_XLOCALE_H
   #include <xlocale.h>
 #endif


### PR DESCRIPTION
* check for the presence of xlocale.h via cmake
* remove related logic from Standard_CLocaleSentry.hxx