### PR TITLE
fix up detection of xlocale.h (cf. issue #675)

### DIFF
--- a/adm/cmake/config/oce_build_config.h.cmake
+++ b/adm/cmake/config/oce_build_config.h.cmake
@@ -19,6 +19,9 @@
 /* Define to 1 if you have the <atomic.h> header file. */
 #cmakedefine OCE_HAVE_ATOMIC_H 1
 
+/* Define to 1 if you have the <xlocale.h> header file. */
+#cmakedefine HAVE_XLOCALE_H 1
+
 /* Define to 1 if the localtime_r function is available. */
 #cmakedefine HAVE_LOCALTIME_R 1
 

--- a/src/Standard/Standard_CLocaleSentry.hxx
+++ b/src/Standard/Standard_CLocaleSentry.hxx
@@ -16,17 +16,11 @@
 #ifndef _Standard_CLocaleSentry_H__
 #define _Standard_CLocaleSentry_H__
 
+#include <oce-config.h>
+
 #include <Standard_Macro.hxx>
 
 #include <locale.h>
-
-#ifndef HAVE_XLOCALE_H
-//! "xlocale.h" available in Mac OS X and glibc (Linux) for a long time as an extension
-//! and become part of POSIX since '2008.
-  #if defined(__APPLE__)
-    #define HAVE_XLOCALE_H
-  #endif
-#endif // ifndef HAVE_LOCALE_H
 
 #ifdef HAVE_XLOCALE_H
   #include <xlocale.h>


### PR DESCRIPTION
* since commit aa1321e68cc004e3debe38d79ae74581a617c767, the presence of xlocale.h is checked via cmake
* however we failed to propagate this information into the header files
* with this fix, one can revert the workaround from 1a575f2e14889fd894d448ed65217a61bcb114df