### PR TITLE
fix OCAFExportTestSuite failures by setting LD_LIBRARY_PATH (issue #700)

### DIFF
--- a/test/OCAFExport_test/CMakeLists.txt
+++ b/test/OCAFExport_test/CMakeLists.txt
@@ -5,6 +5,6 @@ if (OCE_OCAF AND NOT OCE_DISABLE_X11)
 	file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../src/StdResource" BuildPluginDir)
 	# Semi-colon is a delimiter in SET_TESTS_PROPERTIES and have to be escaped
 	string(REPLACE ";" "\\;" BuildPluginDir "${BuildPluginDir}")
-	set_tests_properties(OCAFExportTestSuite.testExportAscii PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_StandardDefaults=${BuildPluginDir}")
-	set_tests_properties(OCAFExportTestSuite.testExportNonAscii PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_StandardDefaults=${BuildPluginDir}")
+	set_tests_properties(OCAFExportTestSuite.testExportAscii PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_StandardDefaults=${BuildPluginDir};LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${LIBRARY_OUTPUT_PATH}")
+	set_tests_properties(OCAFExportTestSuite.testExportNonAscii PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_StandardDefaults=${BuildPluginDir};LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${LIBRARY_OUTPUT_PATH}")
 endif ()


### PR DESCRIPTION
fix issue #700