### PR TITLE
OCE patch used on OpenBSD

### DIFF
--- a/src/OSD/OSD_MemInfo.cxx
+++ b/src/OSD/OSD_MemInfo.cxx
@@ -31,7 +31,9 @@
   #include <malloc/malloc.h>
 #else
   #include <unistd.h>
-  #include <malloc.h>
+  #ifndef __OpenBSD__
+    #include <malloc.h>
+  #endif
 #endif
 
 #include <string>

--- a/src/StepFile/recfile.pc
+++ b/src/StepFile/recfile.pc
@@ -16,7 +16,7 @@
 #include "stdio.h"
 #include "string.h"
 #include "stdlib.h"
-#if (!defined(_WIN32) && !defined(__APPLE__))
+#if (!defined(_WIN32) && !defined(__APPLE__) && !defined(__OpenBSD__))
 #include "malloc.h"
 #endif
 #include "recfile.ph" 


### PR DESCRIPTION
Here are the patches we are currently using to get OCE to compile on OpenBSD.
Thanks.