### PR TITLE
Fix implicit conversion bug in C++11

### DIFF
--- a/src/IVtkVTK/IVtkVTK_ShapeData.cxx
+++ b/src/IVtkVTK/IVtkVTK_ShapeData.cxx
@@ -104,7 +104,8 @@ void IVtkVTK_ShapeData::InsertLine (const IVtk_IdType   theShapeID,
                                     const IVtk_PointId  thePointId2,
                                     const IVtk_MeshType theMeshType)
 {
-  vtkIdType aPoints[2] = { thePointId1, thePointId2 };
+  vtkIdType aPoints[2] = { static_cast<vtkIdType>(thePointId1),
+                           static_cast<vtkIdType>(thePointId2)};
   myPolyData->InsertNextCell (VTK_LINE, 2, aPoints);
   const vtkIdType aShapeIDVTK = theShapeID;
   const vtkIdType aType = theMeshType;
@@ -165,7 +166,9 @@ void IVtkVTK_ShapeData::InsertTriangle (const IVtk_IdType   theShapeID,
                                         const IVtk_PointId  thePointId3,
                                         const IVtk_MeshType theMeshType)
 {
-  vtkIdType aPoints[3] = { thePointId1, thePointId2, thePointId3 };
+  vtkIdType aPoints[3] = { static_cast<vtkIdType>(thePointId1),
+                           static_cast<vtkIdType>(thePointId2),
+                           static_cast<vtkIdType>(thePointId3)};
   myPolyData->InsertNextCell (VTK_TRIANGLE, 3, aPoints);
   const vtkIdType aShapeIDVTK = theShapeID;
   const vtkIdType aType = theMeshType;


### PR DESCRIPTION
I'm compiling opencascade oce on macOS 10.15.6 with clang-7 under Nix. clang-7 uses the "gnu++14" language standard for C++ by default, if nothing else is specified. I couldn't find that opencascade oce requests an explicit C++ standard for compilation.
IVtkVTK_ShapeData.cxx contains a narrowing non-constant cast in an initializer lists, which is illegal in C++11 and above. I fixed it by making it an explicit cast:

```
../src/IVtkVTK/IVtkVTK_ShapeData.cxx:107:28: error: non-constant-expression cannot be narrowed from type 'IVtk_PointId' (aka 'unsigned long') to 'vtkIdType' (aka 'long long') in initializer list [-Wc++11-narrowing]
  vtkIdType aPoints[2] = { thePointId1, thePointId2 };
                           ^~~~~~~~~~~
../src/IVtkVTK/IVtkVTK_ShapeData.cxx:107:28: note: insert an explicit cast to silence this issue
  vtkIdType aPoints[2] = { thePointId1, thePointId2 };
                           ^~~~~~~~~~~
                           static_cast<vtkIdType>( )
../src/IVtkVTK/IVtkVTK_ShapeData.cxx:107:41: error: non-constant-expression cannot be narrowed from type 'IVtk_PointId' (aka 'unsigned long') to 'vtkIdType' (aka 'long long') in initializer list [-Wc++11-narrowing]
  vtkIdType aPoints[2] = { thePointId1, thePointId2 };
                                        ^~~~~~~~~~~
../src/IVtkVTK/IVtkVTK_ShapeData.cxx:107:41: note: insert an explicit cast to silence this issue
  vtkIdType aPoints[2] = { thePointId1, thePointId2 };
                                        ^~~~~~~~~~~
                                        static_cast<vtkIdType>( )
../src/IVtkVTK/IVtkVTK_ShapeData.cxx:168:28: error: non-constant-expression cannot be narrowed from type 'IVtk_PointId' (aka 'unsigned long') to 'vtkIdType' (aka 'long long') in initializer list [-Wc++11-narrowing]
  vtkIdType aPoints[3] = { thePointId1, thePointId2, thePointId3 };
                           ^~~~~~~~~~~
../src/IVtkVTK/IVtkVTK_ShapeData.cxx:168:28: note: insert an explicit cast to silence this issue
  vtkIdType aPoints[3] = { thePointId1, thePointId2, thePointId3 };
                           ^~~~~~~~~~~
                           static_cast<vtkIdType>( )
../src/IVtkVTK/IVtkVTK_ShapeData.cxx:168:41: error: non-constant-expression cannot be narrowed from type 'IVtk_PointId' (aka 'unsigned long') to 'vtkIdType' (aka 'long long') in initializer list [-Wc++11-narrowing]
  vtkIdType aPoints[3] = { thePointId1, thePointId2, thePointId3 };
                                        ^~~~~~~~~~~
../src/IVtkVTK/IVtkVTK_ShapeData.cxx:168:41: note: insert an explicit cast to silence this issue
  vtkIdType aPoints[3] = { thePointId1, thePointId2, thePointId3 };
                                        ^~~~~~~~~~~
                                        static_cast<vtkIdType>( )
../src/IVtkVTK/IVtkVTK_ShapeData.cxx:168:54: error: non-constant-expression cannot be narrowed from type 'IVtk_PointId' (aka 'unsigned long') to 'vtkIdType' (aka 'long long') in initializer list [-Wc++11-narrowing]
  vtkIdType aPoints[3] = { thePointId1, thePointId2, thePointId3 };
                                                     ^~~~~~~~~~~
../src/IVtkVTK/IVtkVTK_ShapeData.cxx:168:54: note: insert an explicit cast to silence this issue
  vtkIdType aPoints[3] = { thePointId1, thePointId2, thePointId3 };
                                                     ^~~~~~~~~~~
                                                     static_cast<vtkIdType>( )
```